### PR TITLE
Exclude workers in webpack.server.config.js

### DIFF
--- a/webpack.server.config.js
+++ b/webpack.server.config.js
@@ -36,7 +36,7 @@ var config = {
     rules: [
       {
         test: /\.(j|t)s(x?)$/,
-        exclude: /node_modules/,
+        exclude: [/node_modules/, /.*worker.*js$/],
         use: [
           'cache-loader',
           {


### PR DESCRIPTION
Exclude workers in webpack.server.config.js

Dramatic difference in server build time:

Before:
```
server_bgio.js  29.7 MiB       0  [emitted]  server_bgio
server_web.js  29.8 MiB       1  [emitted]  server_web     

Done in 26.35s.                                                                                                                                                                               
```

After:
``` 
server_bgio.js   5.3 MiB       0  [emitted]  server_bgio
server_web.js  5.32 MiB       1  [emitted]  server_web 

Done in 2.96s.                                                                                 
```