### PR TITLE
Keep the join order on rooms

### DIFF
--- a/fbg-server/src/rooms/RoomUtil.ts
+++ b/fbg-server/src/rooms/RoomUtil.ts
@@ -12,10 +12,8 @@ export function roomEntityToRoom(roomEntity: RoomEntity): Room {
       roomEntity.userMemberships.find((membership) => membership.isCreator)
         .user,
     ),
-    users: roomEntity.userMemberships
-      .map((membership) => userEntityToUser(membership.user))
-      .sort((a, b) =>
-        a.nickname.toLowerCase().localeCompare(b.nickname.toLowerCase()),
-      ),
+    users: roomEntity.userMemberships.map((membership) =>
+      userEntityToUser(membership.user),
+    ),
   };
 }

--- a/fbg-server/src/rooms/rooms.service.spec.ts
+++ b/fbg-server/src/rooms/rooms.service.spec.ts
@@ -72,7 +72,8 @@ describe('RoomsService', () => {
     );
     const aliceId = await usersService.newUser({ nickname: 'alice' });
     const result = await service.checkin(aliceId, room.id);
-    expect(result.room.users.length).toEqual(2);
+    expect(result.room.users[0].nickname).toEqual('bob');
+    expect(result.room.users[1].nickname).toEqual('alice');
   });
 
   it('should not allow room to go over capacity', async () => {
@@ -106,7 +107,8 @@ describe('RoomsService', () => {
     const aliceId = await usersService.newUser({ nickname: 'alice' });
     await service.checkin(aliceId, room.id);
     const newRoom = await service.getRoom(room.id);
-    expect(newRoom.users.length).toEqual(2);
+    expect(newRoom.users[0].nickname).toEqual('bob');
+    expect(newRoom.users[1].nickname).toEqual('alice');
   });
 
   it('should give the match id after creation', async () => {

--- a/fbg-server/src/rooms/rooms.service.ts
+++ b/fbg-server/src/rooms/rooms.service.ts
@@ -71,15 +71,16 @@ export class RoomsService {
 
   /** Gets a raw RoomEntity, with user information populated. */
   async getRoomEntity(roomId: string): Promise<RoomEntity> {
-    const roomEntity = await this.roomRepository.findOne({
-      where: {
-        id: roomId,
-        userMemberships: {
-          lastSeen: MoreThan(Date.now() - CHECKIN_PERIOD * 3),
-        },
-      },
-      relations: ['match', 'userMemberships', 'userMemberships.user'],
-    });
+    const roomEntity = await this.roomRepository
+      .createQueryBuilder('room')
+      .leftJoinAndSelect('room.match', 'match')
+      .leftJoinAndSelect('room.userMemberships', 'userMemberships')
+      .leftJoinAndSelect('userMemberships.user', 'user')
+      .where('room.id = :roomId', { roomId })
+      .orderBy({
+        'userMemberships.id': 'ASC',
+      })
+      .getOne();
     if (!roomEntity) {
       throw new HttpException(
         `Room id "${roomId}" does not exist`,


### PR DESCRIPTION
This makes so the creator of the room is always the first player on the list, which is the assumption made by Secret codes.

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 90% or better (or you have a story for why it's ok).
