### PR TITLE
Add score table to Hangman.

### DIFF
--- a/web/src/games/hangman/board.css
+++ b/web/src/games/hangman/board.css
@@ -1,15 +1,3 @@
-.scoreTable td, th, table {
-  border: 1px solid grey;
-}
-
-.scoreTable th {
-  font-size: 35px;
-}
-
-.currentPlayerScore {
-  background-color: goldenrod;
-}
-
 .scoreLayout {
   display: flex;
   flex-direction: column;
@@ -18,12 +6,4 @@
   text-align: center;
   margin: 16px;
   padding: 16px;
-}
-
-.midGameScore {
-  text-color: white;
-}
-
-.endOfGameScore {
-  text-color: black;
 }

--- a/web/src/games/hangman/board.css
+++ b/web/src/games/hangman/board.css
@@ -1,0 +1,29 @@
+.scoreTable td, th, table {
+  border: 1px solid grey;
+}
+
+.scoreTable th {
+  font-size: 35px;
+}
+
+.currentPlayerScore {
+  background-color: goldenrod;
+}
+
+.scoreLayout {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  margin: 16px;
+  padding: 16px;
+}
+
+.midGameScore {
+  text-color: white;
+}
+
+.endOfGameScore {
+  text-color: black;
+}

--- a/web/src/games/hangman/board.test.tsx
+++ b/web/src/games/hangman/board.test.tsx
@@ -3,10 +3,9 @@ import { Client } from 'boardgame.io/client';
 import { HangmanGame } from './game';
 import Board from './board';
 import { GameMode } from 'components/App/Game/GameModePicker';
-import { WrapperBoard } from 'boardgame.io/react';
 
 let wrapper: Enzyme.ReactWrapper;
-let client: WrapperBoard;
+let client;
 let instance: any;
 
 const updateGameProps = () => {
@@ -40,8 +39,8 @@ describe('Hangman UI', () => {
           gameCode: 'hangman',
           mode: GameMode.LocalFriend,
           players: [
-            { playerID: 0, name: 'Player A', roomID: 'fooroom' },
-            { playerID: 1, name: 'Player B', roomID: 'fooroom' },
+            { playerID: 0, name: 'Player A' },
+            { playerID: 1, name: 'Player B' },
           ],
         }}
       />,

--- a/web/src/games/hangman/board.test.tsx
+++ b/web/src/games/hangman/board.test.tsx
@@ -39,6 +39,10 @@ describe('Hangman UI', () => {
         gameArgs={{
           gameCode: 'hangman',
           mode: GameMode.LocalFriend,
+          players: [
+            { playerID: 0, name: 'Player A', roomID: 'fooroom' },
+            { playerID: 1, name: 'Player B', roomID: 'fooroom' },
+          ],
         }}
       />,
     );
@@ -121,10 +125,15 @@ describe('Hangman UI', () => {
 
   it('should show gameover', () => {
     const ctx = { gameover: true, currentPlayer: '0' };
-    const G = { players: { '1': { secret: 'foo' } } };
+    const G = { players: { '1': { secret: 'foo', guesses: {} }, '0': { secret: 'bar', guesses: {} } } };
     wrapper.setProps({ G, ctx });
 
     expect(wrapper.text()).toContain('Game Over, Player A won!');
+    const scoreRows = wrapper.find('.scoreTable tbody tr');
+    expect(scoreRows.at(0).text()).toContain('Player A');
+    expect(scoreRows.at(0).text()).toContain('0');
+    expect(scoreRows.at(1).text()).toContain('Player B');
+    expect(scoreRows.at(1).text()).toContain('0');
   });
 
   it('should show that the guess was CORRECT', () => {
@@ -140,6 +149,11 @@ describe('Hangman UI', () => {
 
     expect(wrapper.text()).toContain('Your guess was CORRECT');
     expect(wrapper.text()).toContain('Your score is 75 points');
+    const scoreRows = wrapper.find('.scoreTable tbody tr');
+    expect(scoreRows.at(0).text()).toContain('Player A');
+    expect(scoreRows.at(0).text()).toContain('75');
+    expect(scoreRows.at(1).text()).toContain('Player B');
+    expect(scoreRows.at(1).text()).toContain('0');
   });
 
   it('should show that the guess was INCORRECT', () => {
@@ -162,6 +176,10 @@ describe('Hangman UI', () => {
       const gameArgs = {
         gameCode: 'hangman',
         mode: GameMode.OnlineFriend,
+        players: [
+          { playerID: 0, name: 'Player A', roomID: 'fooroom' },
+          { playerID: 1, name: 'Player B', roomID: 'fooroom' },
+        ],
       };
       wrapper.setProps({ gameArgs });
     });

--- a/web/src/games/hangman/board.test.tsx
+++ b/web/src/games/hangman/board.test.tsx
@@ -124,12 +124,12 @@ describe('Hangman UI', () => {
   });
 
   it('should show gameover', () => {
-    const ctx = { gameover: true, currentPlayer: '0' };
-    const G = { players: { '1': { secret: 'foo', guesses: {} }, '0': { secret: 'bar', guesses: {} } } };
+    const ctx = { gameover: true, currentPlayer: '1' };
+    const G = { players: { '1': { secret: 'foo', guesses: { a: [1] } }, '0': { secret: 'bar', guesses: {} } } };
     wrapper.setProps({ G, ctx });
 
-    expect(wrapper.text()).toContain('Game Over, Player A won!');
-    const scoreRows = wrapper.find('.scoreTable tbody tr');
+    expect(wrapper.text()).toContain('Game Over, Player B won!');
+    const scoreRows = wrapper.find('.scoreboard tbody tr');
     expect(scoreRows.at(0).text()).toContain('Player A');
     expect(scoreRows.at(0).text()).toContain('0');
     expect(scoreRows.at(1).text()).toContain('Player B');
@@ -149,11 +149,6 @@ describe('Hangman UI', () => {
 
     expect(wrapper.text()).toContain('Your guess was CORRECT');
     expect(wrapper.text()).toContain('Your score is 75 points');
-    const scoreRows = wrapper.find('.scoreTable tbody tr');
-    expect(scoreRows.at(0).text()).toContain('Player A');
-    expect(scoreRows.at(0).text()).toContain('75');
-    expect(scoreRows.at(1).text()).toContain('Player B');
-    expect(scoreRows.at(1).text()).toContain('0');
   });
 
   it('should show that the guess was INCORRECT', () => {

--- a/web/src/games/hangman/board.tsx
+++ b/web/src/games/hangman/board.tsx
@@ -5,6 +5,7 @@ import Typography from '@material-ui/core/Typography';
 import { EnterWordPrompt } from './EnterWordPrompt';
 import css from './board.css';
 import { isOnlineGame } from '../common/gameMode';
+import { IScore, Scoreboard } from '../common/Scoreboard';
 import { grey } from '@material-ui/core/colors';
 import { Modal, Button } from '@material-ui/core';
 import { isPlayersTurn } from 'games/common/GameUtil';
@@ -282,28 +283,20 @@ export class Board extends React.Component<IBoardProps, IBoardState> {
       }
     }
 
+    const scores: IScore[] = this.props.gameArgs.players.map((player, i) => {
+      const hangmanPlayer = this.props.G.players[i];
+      return { playerID: `${player.playerID}`, score: getScore(hangmanPlayer.guesses) };
+    });
     const cssClasses = [css.scoreLayout];
+    let scoreBoard = null;
     if (this.props.ctx.currentPlayer === '1') {
       nextButton = null;
       cssClasses.push(css.endOfGameScore);
+      scoreBoard = (
+        <Scoreboard scoreboard={scores} players={this.props.gameArgs.players} playerID={this.props.ctx.playerID} />
+      );
     } else {
       cssClasses.push(css.midGameScore);
-    }
-
-    const tableRows = [];
-    for (let i = 0; i < this.props.gameArgs.players.length; i++) {
-      const hangmanPlayer = this.props.G.players[i];
-      const playerInRoom = this.props.gameArgs.players[i];
-      tableRows.push(
-        <tr key={playerInRoom.name}>
-          <td>
-            <b>{playerInRoom.name}</b>
-          </td>
-          <td>
-            <b>{getScore(hangmanPlayer.guesses)}</b>
-          </td>
-        </tr>,
-      );
     }
 
     return (
@@ -311,15 +304,7 @@ export class Board extends React.Component<IBoardProps, IBoardState> {
         {guessMessage}
         <br />
         {extraMessage}
-        <table className={css.scoreTable}>
-          <thead>
-            <tr>
-              <th>Player</th>
-              <th>Score</th>
-            </tr>
-          </thead>
-          <tbody>{tableRows}</tbody>
-        </table>
+        {scoreBoard}
         <br />
         {nextButton}
       </Typography>

--- a/web/src/games/hangman/board.tsx
+++ b/web/src/games/hangman/board.tsx
@@ -3,6 +3,7 @@ import { IGameArgs } from 'components/App/Game/GameBoardWrapper';
 import { GameLayout } from 'components/App/Game/GameLayout';
 import Typography from '@material-ui/core/Typography';
 import { EnterWordPrompt } from './EnterWordPrompt';
+import css from './board.css';
 import { isOnlineGame } from '../common/gameMode';
 import { grey } from '@material-ui/core/colors';
 import { Modal, Button } from '@material-ui/core';
@@ -280,21 +281,48 @@ export class Board extends React.Component<IBoardProps, IBoardState> {
         nextButton = null;
       }
     }
-    let textColor = 'white';
+
+    const cssClasses = [css.scoreLayout];
     if (this.props.ctx.currentPlayer === '1') {
       nextButton = null;
-      textColor = 'black';
+      cssClasses.push(css.endOfGameScore);
+    } else {
+      cssClasses.push(css.midGameScore);
     }
+
+    const tableRows = [];
+    for (let i = 0; i < this.props.gameArgs.players.length; i++) {
+      const hangmanPlayer = this.props.G.players[i];
+      const playerInRoom = this.props.gameArgs.players[i];
+      tableRows.push(
+        <tr key={playerInRoom.name}>
+          <td>
+            <b>{playerInRoom.name}</b>
+          </td>
+          <td>
+            <b>{getScore(hangmanPlayer.guesses)}</b>
+          </td>
+        </tr>,
+      );
+    }
+
     return (
-      <div>
-        <Typography variant="h6" style={{ textAlign: 'center', color: textColor, margin: '16px', padding: '16px' }}>
-          {guessMessage}
-          <br />
-          {extraMessage}
-          <br />
-          {nextButton}
-        </Typography>
-      </div>
+      <Typography variant="h6" className={cssClasses.join(' ')}>
+        {guessMessage}
+        <br />
+        {extraMessage}
+        <table className={css.scoreTable}>
+          <thead>
+            <tr>
+              <th>Player</th>
+              <th>Score</th>
+            </tr>
+          </thead>
+          <tbody>{tableRows}</tbody>
+        </table>
+        <br />
+        {nextButton}
+      </Typography>
     );
   }
 

--- a/web/src/games/hangman/board.tsx
+++ b/web/src/games/hangman/board.tsx
@@ -287,20 +287,16 @@ export class Board extends React.Component<IBoardProps, IBoardState> {
       const hangmanPlayer = this.props.G.players[i];
       return { playerID: `${player.playerID}`, score: getScore(hangmanPlayer.guesses) };
     });
-    const cssClasses = [css.scoreLayout];
     let scoreBoard = null;
     if (this.props.ctx.currentPlayer === '1') {
       nextButton = null;
-      cssClasses.push(css.endOfGameScore);
       scoreBoard = (
         <Scoreboard scoreboard={scores} players={this.props.gameArgs.players} playerID={this.props.ctx.playerID} />
       );
-    } else {
-      cssClasses.push(css.midGameScore);
     }
 
     return (
-      <Typography variant="h6" className={cssClasses.join(' ')}>
+      <Typography variant="h6" className={css.scoreLayout}>
         {guessMessage}
         <br />
         {extraMessage}

--- a/web/src/games/hangman/util.test.ts
+++ b/web/src/games/hangman/util.test.ts
@@ -1,5 +1,5 @@
 import { HangmanState, Guesses } from './definitions';
-import { setSecret, selectLetter, getWinner, getMaskedWord, isValidWord, isGuessCorrect } from './util';
+import { setSecret, selectLetter, getWinner, getMaskedWord, getScore, isValidWord, isGuessCorrect } from './util';
 
 describe('hangman', () => {
   describe('setSecret()', () => {
@@ -204,6 +204,12 @@ describe('hangman', () => {
 
       expect(isGuessCorrect(fakeG, '0')).toEqual(true);
       expect(isGuessCorrect(fakeG, '1')).toEqual(false);
+    });
+  });
+
+  describe('getScore()', () => {
+    it('should return 0 when player has no guesses.', () => {
+      expect(getScore([])).toEqual(0);
     });
   });
 });

--- a/web/src/games/hangman/util.ts
+++ b/web/src/games/hangman/util.ts
@@ -100,9 +100,15 @@ export function isValidWord(word: string) {
 
 /** Get Score for a given guess made by a player */
 export function getScore(guesses: Guesses) {
-  return getMistakeCount(guesses) >= MAX_MISTAKE_COUNT
-    ? 0
-    : Math.ceil((getCorrectLettersCount(guesses) / (getCorrectLettersCount(guesses) + getMistakeCount(guesses))) * 100);
+  const mistakeCount = getMistakeCount(guesses);
+  if (mistakeCount >= MAX_MISTAKE_COUNT) {
+    return 0;
+  }
+  const correctLettersCount = getCorrectLettersCount(guesses);
+  if (correctLettersCount + mistakeCount == 0) {
+    return 0;
+  }
+  return Math.ceil((getCorrectLettersCount(guesses) / (correctLettersCount + mistakeCount)) * 100);
 }
 
 /** Check in user is done guessing */


### PR DESCRIPTION
The table displays the score for each player on the GameOver screen as well as between turns.

#490 

#### Checklist

* [X] Use a separate branch in your local repo (not `master`).
* [X] Test coverage is 90% or better (or you have a story for why it's ok).

Preview:
Between turns
![Screen Shot 2020-05-30 at 9 54 04 AM](https://user-images.githubusercontent.com/294449/83334644-c3916c80-a25c-11ea-98a4-1627df483266.png)

End of game
![Screen Shot 2020-05-30 at 9 54 22 AM](https://user-images.githubusercontent.com/294449/83334646-c4c29980-a25c-11ea-8366-4ea31cf39a13.png)


