### PR TITLE
Eliminate comments/spaces in SSR rendering

### DIFF
--- a/web/src/infra/common/components/game/GameCard.tsx
+++ b/web/src/infra/common/components/game/GameCard.tsx
@@ -51,7 +51,7 @@ export class GameCard extends React.Component<IGameCardProps, {}> {
     }
     const gameNameHeading = this.props.isLink ? (
       <Typography gutterBottom={false} variant="h4" component="h2" style={{ fontWeight: 300 }}>
-        Play {this.props.game.name}
+        {`Play ${this.props.game.name}`}
       </Typography>
     ) : (
       <Typography gutterBottom={false} variant="h4" component="h1" style={{ fontWeight: 300 }}>


### PR DESCRIPTION
This eliminates comments/spaces in SSR of the name of games:
```html
<h2 ...>Play <!-- -->Chess</h2>
```

![image](https://user-images.githubusercontent.com/304383/84238966-cea09400-aac9-11ea-8615-c81b9bfb22df.png)

#### Checklist

* [X] Use a separate branch in your local repo (not `master`).
* [X] Test coverage is 90% or better (or you have a story for why it's ok).
