### PR TITLE
Fixed Numbering Throughout Zoo Parade

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Always checkout with LF, even on Windows (otherwise linter, CI break)
+* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
 # Always checkout with LF, even on Windows (otherwise linter, CI break)
 * text eol=lf
+
+# Excludes
+*.png binary
+*.jpg binary
+*.xcf binary

--- a/web/src/games/zooparade/components/bbuttons.tsx
+++ b/web/src/games/zooparade/components/bbuttons.tsx
@@ -10,7 +10,7 @@ interface InnerWrapper {
   keyPropagation: string;
 }
 
-const Values = [1, 2, 3, 4, 5];
+const Values = [0, 1, 2, 3, 4];
 
 export class BButtons extends React.Component<InnerWrapper, {}> {
   render() {

--- a/web/src/games/zooparade/components/bcard.tsx
+++ b/web/src/games/zooparade/components/bcard.tsx
@@ -26,8 +26,8 @@ interface InnerWrapper {
 
 export class BCard extends React.Component<InnerWrapper, {}> {
   render() {
-    var cardDisplayValue: string;
-    var image: any;
+    let cardDisplayValue: string;
+    let image: any;
     if (this.props.empty !== null) {
       // No Real Card Face
       cardDisplayValue = '';

--- a/web/src/games/zooparade/components/bcard.tsx
+++ b/web/src/games/zooparade/components/bcard.tsx
@@ -26,11 +26,11 @@ interface InnerWrapper {
 
 export class BCard extends React.Component<InnerWrapper, {}> {
   render() {
-    var cardValue: string;
+    var cardDisplayValue: string;
     var image: any;
     if (this.props.empty !== null) {
       // No Real Card Face
-      cardValue = '';
+      cardDisplayValue = '';
       switch (this.props.empty) {
         case 0:
           image = green;
@@ -56,10 +56,11 @@ export class BCard extends React.Component<InnerWrapper, {}> {
       }
     } else if (!this.props.card) {
       // Card is null, so its hidden
-      cardValue = '';
+      cardDisplayValue = '';
       image = white;
     } else {
-      cardValue = String(this.props.card.value !== null ? this.props.card.value : '');
+      let cardValue = this.props.card.value;
+      cardDisplayValue = String(cardValue !== null ? cardValue + 1 : '');
       switch (this.props.card.color) {
         case 0:
           image = green_with;
@@ -85,7 +86,7 @@ export class BCard extends React.Component<InnerWrapper, {}> {
     return (
       <div className={style.card}>
         <img src={image} />
-        <span>{cardValue}</span>
+        <span>{cardDisplayValue}</span>
       </div>
     );
   }

--- a/web/src/games/zooparade/components/bcardwithhint.tsx
+++ b/web/src/games/zooparade/components/bcardwithhint.tsx
@@ -28,7 +28,7 @@ export class BCardWithHint extends React.Component<BCardWithHintProps, {}> {
     });
     const values = this.props.hint.value.map((value: number, index: number) => {
       const key = this.props.keyPropagation + 'BHint' + index.toString();
-      const cardValue = index + 1;
+      const cardValue = index;
       return (
         <BHintIcon
           key={key}

--- a/web/src/games/zooparade/components/bhinticon.tsx
+++ b/web/src/games/zooparade/components/bhinticon.tsx
@@ -16,11 +16,12 @@ export class BHintIcon extends React.Component<InnerWrapper, {}> {
       <div
         className={css.hint}
         style={{
-          backgroundColor: this.props.hintIcon.color !== -1 ? colors[this.props.hintIcon.color] : 'black',
+          backgroundColor: this.props.hintIcon.color !== -1 ? 
+                           colors[this.props.hintIcon.color] : 'black',
         }}
         key={this.props.keyPropagation}
       >
-        {this.props.hintIcon.value !== -1 ? this.props.hintIcon.value : ' '}
+        {this.props.hintIcon.value !== -1 ? this.props.hintIcon.value + 1 : ' '}
       </div>
     );
   }

--- a/web/src/games/zooparade/components/bhinticon.tsx
+++ b/web/src/games/zooparade/components/bhinticon.tsx
@@ -20,7 +20,7 @@ export class BHintIcon extends React.Component<InnerWrapper, {}> {
         }}
         key={this.props.keyPropagation}
       >
-        {this.props.hintIcon.value !== -1 ? this.props.hintIcon.value + 1 : ' '}
+        {this.props.hintIcon.value !== -1 && this.props.hintIcon.value !== null ? this.props.hintIcon.value + 1 : ' '}
       </div>
     );
   }

--- a/web/src/games/zooparade/components/bhinticon.tsx
+++ b/web/src/games/zooparade/components/bhinticon.tsx
@@ -16,8 +16,7 @@ export class BHintIcon extends React.Component<InnerWrapper, {}> {
       <div
         className={css.hint}
         style={{
-          backgroundColor: this.props.hintIcon.color !== -1 ? 
-                           colors[this.props.hintIcon.color] : 'black',
+          backgroundColor: this.props.hintIcon.color !== -1 ? colors[this.props.hintIcon.color] : 'black',
         }}
         key={this.props.keyPropagation}
       >


### PR DESCRIPTION
The numbers on cards and stuff should display as 1-5 to the user, not 0-4. #620 went some way towards this, but doesn't seem to have had the desired effect. This change fixes this, the way I assumed it would be done when I was working on the code before. I have reverted the internal logic to use 0-4, made sure cards and hints only _display_ 1-5.

This means:
 - The large numbers on the cards now show 1-5 (even after #620, they showed 0-4).
 - Hints aren't kinda broken (they were before, become some of the logic was using 1-5 while the rest of it still expected 0-4).

The fact that the internal logic used 0-4 is an wierd characteristic of the code that should probably be documented to that people don't make the intuitive - but sadly buggy - changes as in #620 (thankfully @Spooky-0 warned me about this when I was working on it originally). Suggestions on how best to do this documentation are very welcome. (The alternative, of course, is a much much more intensive rewrite of the code to use 1-5 throughout, but I'm not sure it's worth it.)

Also, I have no idea about tests and stuff, so if this breaks tests (though really I don't see why it would) I'll need help unbreaking them.

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [ ] Test coverage is 90% or better (or you have a story for why it's ok).
