### PR TITLE
Optimize docker image size by using alpine as base

### DIFF
--- a/fbg-server/Dockerfile
+++ b/fbg-server/Dockerfile
@@ -1,14 +1,14 @@
-# web
+# fbg-server
 FROM fbg-common:latest AS common
-FROM node:14.5.0-buster
-RUN groupadd -g 999 appuser && useradd -m -d /appdata -r -u 999 -g appuser appuser
+FROM node:14.15.0-alpine3.12 AS builder
+RUN addgroup -g 998 appuser && adduser -h /appdata -S -u 997 -G appuser appuser
 RUN rm /bin/su
 USER appuser
 
 # install and cache app dependencies
 COPY --chown=appuser package.json yarn.lock /appdata/
 WORKDIR /appdata
-RUN yarn install
+RUN yarn install && yarn cache clean
 
 # config
 COPY --chown=appuser tsconfig.json tsconfig.build.json nest-cli.json /appdata/
@@ -17,10 +17,18 @@ COPY --chown=appuser tsconfig.json tsconfig.build.json nest-cli.json /appdata/
 COPY --chown=appuser src /appdata/src
 RUN yarn run build
 
+FROM node:14.15.0-alpine3.12
+RUN addgroup -g 998 appuser && adduser -h /appdata -S -u 997 -G appuser appuser
+RUN rm /bin/su
+USER appuser
+WORKDIR /appdata
+
+COPY --chown=appuser package.json /appdata/
+RUN yarn install --production && yarn cache clean
+COPY --chown=appuser --from=builder /appdata/dist /appdata/
 # internal configs for FreeBoardGames.org
 COPY --chown=appuser --from=common /internal /internal
 COPY --chown=appuser --from=common /common /common
 
 # run
 CMD yarn run start:prod
-

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,14 +1,15 @@
 # web
 FROM fbg-common:latest AS common
-FROM node:14.5.0-buster
-RUN groupadd -g 999 appuser && useradd -m -d /appdata -r -u 999 -g appuser appuser
+FROM node:14.15.0-alpine3.12 AS builder
+RUN apk add --no-cache autoconf automake file g++ libtool make nasm libpng-dev libc6-compat
+RUN addgroup -g 998 appuser && adduser -h /appdata -S -u 997 -G appuser appuser
 RUN rm /bin/su
 USER appuser
 
 # install and cache app dependencies
 COPY --chown=appuser tsconfig.json package.json yarn.lock /appdata/
 WORKDIR /appdata
-RUN yarn install
+RUN yarn install  && yarn cache clean
 
 # config
 COPY --chown=appuser tsconfig.server.json webpack.server.config.js /appdata/
@@ -26,6 +27,16 @@ COPY --chown=appuser .storybook /appdata/.storybook
 COPY --chown=appuser docs /appdata/docs
 RUN yarn run build
 
+FROM node:14.15.0-alpine3.12
+RUN addgroup -g 998 appuser && adduser -h /appdata -S -u 997 -G appuser appuser
+RUN rm /bin/su
+USER appuser
+WORKDIR /appdata
+
+COPY --chown=appuser package.json /appdata/
+RUN yarn install --production && yarn cache clean
+COPY --chown=appuser public /appdata/public
+COPY --chown=appuser --from=builder /appdata/server /appdata/
 COPY --chown=appuser docker_run.sh /appdata/
 
 # internal configs for FreeBoardGames.org


### PR DESCRIPTION
#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] I've read and agree with the [contribution guidelines](https://www.freeboardgames.org/docs/?path=/story/documentation-contributing--page).
Current docker image contains yarn package cache and unused dev dependencies.
They are redundant for running in prod.