### PR TITLE
Revert "Optimize docker image size by using alpine as base"

### DIFF
--- a/fbg-server/Dockerfile
+++ b/fbg-server/Dockerfile
@@ -1,14 +1,14 @@
-# fbg-server
+# web
 FROM fbg-common:latest AS common
-FROM node:14.15.0-alpine3.12 AS builder
-RUN addgroup -g 998 appuser && adduser -h /appdata -S -u 997 -G appuser appuser
+FROM node:14.5.0-buster
+RUN groupadd -g 999 appuser && useradd -m -d /appdata -r -u 999 -g appuser appuser
 RUN rm /bin/su
 USER appuser
 
 # install and cache app dependencies
 COPY --chown=appuser package.json yarn.lock /appdata/
 WORKDIR /appdata
-RUN yarn install && yarn cache clean
+RUN yarn install
 
 # config
 COPY --chown=appuser tsconfig.json tsconfig.build.json nest-cli.json /appdata/
@@ -17,18 +17,10 @@ COPY --chown=appuser tsconfig.json tsconfig.build.json nest-cli.json /appdata/
 COPY --chown=appuser src /appdata/src
 RUN yarn run build
 
-FROM node:14.15.0-alpine3.12
-RUN addgroup -g 998 appuser && adduser -h /appdata -S -u 997 -G appuser appuser
-RUN rm /bin/su
-USER appuser
-WORKDIR /appdata
-
-COPY --chown=appuser package.json /appdata/
-RUN yarn install --production && yarn cache clean
-COPY --chown=appuser --from=builder /appdata/dist /appdata/
 # internal configs for FreeBoardGames.org
 COPY --chown=appuser --from=common /internal /internal
 COPY --chown=appuser --from=common /common /common
 
 # run
 CMD yarn run start:prod
+

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,15 +1,14 @@
 # web
 FROM fbg-common:latest AS common
-FROM node:14.15.0-alpine3.12 AS builder
-RUN apk add --no-cache autoconf automake file g++ libtool make nasm libpng-dev libc6-compat
-RUN addgroup -g 998 appuser && adduser -h /appdata -S -u 997 -G appuser appuser
+FROM node:14.5.0-buster
+RUN groupadd -g 999 appuser && useradd -m -d /appdata -r -u 999 -g appuser appuser
 RUN rm /bin/su
 USER appuser
 
 # install and cache app dependencies
 COPY --chown=appuser tsconfig.json package.json yarn.lock /appdata/
 WORKDIR /appdata
-RUN yarn install  && yarn cache clean
+RUN yarn install
 
 # config
 COPY --chown=appuser tsconfig.server.json webpack.server.config.js /appdata/
@@ -27,16 +26,6 @@ COPY --chown=appuser .storybook /appdata/.storybook
 COPY --chown=appuser docs /appdata/docs
 RUN yarn run build
 
-FROM node:14.15.0-alpine3.12
-RUN addgroup -g 998 appuser && adduser -h /appdata -S -u 997 -G appuser appuser
-RUN rm /bin/su
-USER appuser
-WORKDIR /appdata
-
-COPY --chown=appuser package.json /appdata/
-RUN yarn install --production && yarn cache clean
-COPY --chown=appuser public /appdata/public
-COPY --chown=appuser --from=builder /appdata/server /appdata/
 COPY --chown=appuser docker_run.sh /appdata/
 
 # internal configs for FreeBoardGames.org


### PR DESCRIPTION
The images are crashing in loop now:

![image](https://user-images.githubusercontent.com/1034631/100426051-22397680-3045-11eb-9b54-b4251cf981ed.png)

Error on the fbg-server pod:
```
yarn run v1.22.5
$ cross-env NODE_ENV=production node dist/main
internal/modules/cjs/loader.js:883
  throw err;
  ^
Error: Cannot find module '/appdata/dist/main'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)
    at Function.Module._load (internal/modules/cjs/loader.js:725:27)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:72:12)
    at internal/main/run_main_module.js:17:47 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
Error on the web and bgio pod:
```
/bin/sh: ./docker_run.sh: not found
```

Reverts freeboardgames/FreeBoardGames.org#680