### PR TITLE
Don't allow negative input in Mergers

### DIFF
--- a/web/src/games/mergers/components/PlayerActions.test.tsx
+++ b/web/src/games/mergers/components/PlayerActions.test.tsx
@@ -198,7 +198,29 @@ describe('#renderBuyStock', () => {
     it('disables the Buy button and displays an error', () => {
       expect(comp.props().moves.buyStock).not.toHaveBeenCalled();
       expect(comp.find(`.${css.ActionButton}`).at(0).props().disabled).toBeTrue();
-      expect(comp.text()).toContain('Please enter numbers only');
+      expect(comp.text()).toContain('Please enter positive numbers only');
+    });
+  });
+
+  describe('entering a negative value', () => {
+    beforeEach(() => {
+      setUpComponent((G) => {
+        G.players['0'].money = 1000;
+      });
+
+      // player enters a negative value
+      comp
+        .find('input[name="stock-to-buy-input-Toro"]')
+        .at(0)
+        .simulate('change', { target: { name: 'stock-to-buy-input-Toro', value: '-1' } });
+
+      comp.find(`.${css.ActionButton}`).at(0).simulate('click');
+    });
+
+    it('disables the Buy button and displays an error', () => {
+      expect(comp.props().moves.buyStock).not.toHaveBeenCalled();
+      expect(comp.find(`.${css.ActionButton}`).at(0).props().disabled).toBeTrue();
+      expect(comp.text()).toContain('Please enter positive numbers only');
     });
   });
 });
@@ -385,7 +407,24 @@ describe('#renderExchangeStock', () => {
     it('disables the Buy button and displays an error', () => {
       expect(comp.props().moves.swapAndSellStock).not.toHaveBeenCalled();
       expect(comp.find(`.${css.ActionButton}`).at(0).props().disabled).toBeTrue();
-      expect(comp.text()).toContain('Please enter numbers only');
+      expect(comp.text()).toContain('Please enter positive numbers only');
+    });
+  });
+
+  describe('entering a negative value', () => {
+    beforeEach(() => {
+      comp
+        .find('input[name="stock-to-exchange-input-Swap"]')
+        .at(0)
+        .simulate('change', { target: { name: 'stock-to-exchange-input-Swap', value: '-1' } });
+
+      comp.find(`.${css.ActionButton}`).at(0).simulate('click');
+    });
+
+    it('disables the Buy button and displays an error', () => {
+      expect(comp.props().moves.swapAndSellStock).not.toHaveBeenCalled();
+      expect(comp.find(`.${css.ActionButton}`).at(0).props().disabled).toBeTrue();
+      expect(comp.text()).toContain('Please enter positive numbers only');
     });
   });
 });

--- a/web/src/games/mergers/components/PlayerActions.tsx
+++ b/web/src/games/mergers/components/PlayerActions.tsx
@@ -86,8 +86,8 @@ export class PlayerActions extends React.Component<PlayerActionsProps, PlayerAct
       if (numToBuy === 0) {
         continue;
       }
-      if (Number.isNaN(numToBuy)) {
-        return 'Please enter numbers only';
+      if (Number.isNaN(numToBuy) || numToBuy < 0) {
+        return 'Please enter positive numbers only';
       }
       const numAvailable = this.props.availableStocks[chain];
       if (numToBuy > numAvailable) {
@@ -113,19 +113,19 @@ export class PlayerActions extends React.Component<PlayerActionsProps, PlayerAct
   }
 
   validateStocksToExchange(): string {
-    const parsed = this.parseStocksToExchange();
-    if (Number.isNaN(parsed.sell) || Number.isNaN(parsed.swap)) {
-      return 'Please enter numbers only';
+    const { swap, sell } = this.parseStocksToExchange();
+    if (Number.isNaN(sell) || sell < 0 || Number.isNaN(swap) || swap < 0) {
+      return 'Please enter positive numbers only';
     }
     const numStocksToExchange = this.playerState().stocks[this.props.merger.chainToMerge];
-    if (parsed.swap + parsed.sell > numStocksToExchange) {
+    if (swap + sell > numStocksToExchange) {
       return `You only have ${numStocksToExchange} ${this.props.merger.chainToMerge} stock`;
     }
-    if (parsed.swap % 2 !== 0) {
+    if (swap % 2 !== 0) {
       return `You may only swap an even number of stock (2 ${this.props.merger.chainToMerge} for 1 ${this.props.merger.survivingChain})`;
     }
     const numAvailableToSwapFor = this.props.availableStocks[this.props.merger.survivingChain];
-    if (parsed.swap / 2 > numAvailableToSwapFor) {
+    if (swap / 2 > numAvailableToSwapFor) {
       return `There are only ${numAvailableToSwapFor} ${this.props.merger.survivingChain} stocks available to swap for`;
     }
     return '';

--- a/web/src/games/mergers/game.ts
+++ b/web/src/games/mergers/game.ts
@@ -104,15 +104,15 @@ export function buyStock(G: IG, ctx: Ctx, order: Partial<Record<Chain, number>>)
     const hotels = getHotels(G);
     const player = G.players[ctx.playerID];
     let purchasesRemaining = 3;
-    Object.keys(Chain).forEach((key) => {
+    for (const key of Object.keys(Chain)) {
       const chain = Chain[key];
       const num = order[chain];
-      if (!num) {
-        return;
+      if (!num || num < 0) {
+        continue;
       }
       const stockPrice = hotels.priceOfStock(chain);
       if (stockPrice === undefined) {
-        return;
+        continue;
       }
       let stocksToBuy = Math.min(num, Math.min(G.availableStocks[chain], purchasesRemaining));
       if (!G.lastMove) {
@@ -128,7 +128,7 @@ export function buyStock(G: IG, ctx: Ctx, order: Partial<Record<Chain, number>>)
         stocksToBuy--;
         purchasesRemaining--;
       }
-    });
+    }
   }
 
   if (!G.lastMove) {
@@ -230,6 +230,7 @@ export function swapAndSellStock(G: IG, ctx: Ctx, swap?: number, sell?: number) 
   }
 
   let toSwap = swap || 0;
+  toSwap = Math.max(toSwap, 0);
   toSwap = Math.min(toSwap, player.stocks[chainToMerge]);
   toSwap = Math.min(toSwap, G.availableStocks[survivingChain] * 2);
   toSwap = roundDownToNearest2(toSwap);
@@ -246,6 +247,7 @@ export function swapAndSellStock(G: IG, ctx: Ctx, swap?: number, sell?: number) 
   G.availableStocks[survivingChain] -= toSwap / 2;
 
   let toSell = sell || 0;
+  toSell = Math.max(toSell, 0);
   toSell = Math.min(toSell, player.stocks[chainToMerge] || 0);
 
   // players sells stocks


### PR DESCRIPTION
Prevented negative input for buying and swapping/selling, in the backend and frontend.

![image](https://user-images.githubusercontent.com/10420620/100876069-e5221980-3474-11eb-9d93-29e9db5efb06.png)

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] I've read and agree with the [contribution guidelines](https://www.freeboardgames.org/docs/?path=/story/documentation-contributing--page).
