### PR TITLE
Updated Bingo horizontal victory condition

### DIFF
--- a/web/src/games/bingo/game.ts
+++ b/web/src/games/bingo/game.ts
@@ -80,7 +80,7 @@ export const BingoGame: Game<IGameState> = {
         }
         // rows
         for (let yi = 0; yi < GRID_SIZE; yi++) {
-          found[yi + GRID_SIZE] = found[yi + GRID_SIZE] + (yPos === 0 && marked);
+          found[yi + GRID_SIZE] = found[yi + GRID_SIZE] + (yPos === yi && marked);
         }
         // diagonal
         found[10] = found[10] + (xPos === yPos && marked);


### PR DESCRIPTION
The game was not declaring victory for all horizontal rows, it was doing it only for first row

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] I've read and agree with the [contribution guidelines](https://www.freeboardgames.org/docs/?path=/story/documentation-contributing--page).
