### PR TITLE
Fix Mergers header

### DIFF
--- a/web/src/games/mergers/Board.module.css
+++ b/web/src/games/mergers/Board.module.css
@@ -32,10 +32,7 @@
 }
 
 .MergersContainer {
-  padding: 1em;
-  max-height: 100vh;
-  overflow-y: auto;
-  padding: 50px 10px 28px 10px;
+  margin: 32px 10px 28px 10px;
   box-sizing: border-box;
   color: var(--mergers-color);
   background-color: var(--mergers-background-color);


### PR DESCRIPTION
Hiding the chat box makes the header disappear. This fixes that by changing the padding to margin, and adjusts the height and overflow-y of the container since the scroll bar is now unnecessary on the board component.

Before:
![image](https://user-images.githubusercontent.com/10420620/103601267-45becf00-4ed7-11eb-954d-4eb54e9d7c2f.png)

After:
![image](https://user-images.githubusercontent.com/10420620/103601305-58390880-4ed7-11eb-9173-692edbfb0866.png)]

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] I've read and agree with the [contribution guidelines](https://www.freeboardgames.org/docs/?path=/story/documentation-contributing--page).
