### PR TITLE
[i18n] replace usage of next/router for infra/i18n (part. 4)

### DIFF
--- a/web/src/infra/lobby/GameCardWithOverlay.tsx
+++ b/web/src/infra/lobby/GameCardWithOverlay.tsx
@@ -3,7 +3,7 @@ import { IGameDef } from 'gamesShared/definitions/game';
 import Typography from '@material-ui/core/Typography';
 import { withStyles } from '@material-ui/core/styles';
 import css from './GameCardWithOverlay.module.css';
-import Router from 'next/router';
+import { Router } from 'infra/i18n';
 
 interface GameCardWithOverlayProps {
   game: IGameDef;

--- a/web/src/infra/lobby/NewRoomModal.tsx
+++ b/web/src/infra/lobby/NewRoomModal.tsx
@@ -5,7 +5,7 @@ import css from './NewRoomModal.module.css';
 import { OccupancySelect } from 'infra/common/components/game/OccupancySelect';
 import NicknameRequired from 'infra/common/components/auth/NicknameRequired';
 import { LobbyService } from 'infra/common/services/LobbyService';
-import Router from 'next/router';
+import { Router } from 'infra/i18n';
 import getMessagePage from 'infra/common/components/alert/MessagePage';
 import { IGameDef } from 'gamesShared/definitions/game';
 import { GamePickerModal } from 'infra/common/components/game/GamePickerModal';


### PR DESCRIPTION
### Goals

| Scenarios | Result | Evidence |
| -- | -- | -- |
| When clicking on an existing public room | `/:lang/room/:id` | https://user-images.githubusercontent.com/2018161/116763153-3833d480-a9f3-11eb-9689-a8d129d26a55.mp4 |
| When creating a public room | `/:lang/room/:id` | https://user-images.githubusercontent.com/2018161/116763162-4681f080-a9f3-11eb-84f4-006d057e916e.mp4 |
| When creating a new room | gets `roomID` properly | https://user-images.githubusercontent.com/2018161/116763706-c9577b00-a9f4-11eb-95ed-dcf3a1545697.mp4 |
| When starting a match | `/:lang/match/:id` | same than before |
| When leaving a room | `/:lang/` | same than before |