### PR TITLE
[i18n] change next/router for infra/i18n (part. 5) 

### DIFF
--- a/web/src/infra/game/AIOrLocalGame.tsx
+++ b/web/src/infra/game/AIOrLocalGame.tsx
@@ -17,7 +17,7 @@ interface AILocalGameProps {
   mode: string;
 }
 
-export default class extends React.Component<AILocalGameProps, {}> {
+export default class AILocalGame extends React.Component<AILocalGameProps, {}> {
   render() {
     if (this.props.gameDef) {
       return (

--- a/web/src/infra/i18n/hooks/useHref.ts
+++ b/web/src/infra/i18n/hooks/useHref.ts
@@ -1,11 +1,8 @@
 import { LinkProps } from 'next/link';
 import { nextI18Next } from '../config';
-import translatedPaths from '../translatedPaths';
 import { translateHref } from '../utils';
 
 export function useHref(href: LinkProps['href']): LinkProps['href'] {
-  if (process.env.NEXT_PUBLIC_I18N_ENABLED !== 'true') return href;
-
   const { i18n } = nextI18Next.useTranslation();
-  return translateHref({ href, language: i18n.language, translatedPaths: translatedPaths });
+  return translateHref({ href, language: i18n.language });
 }

--- a/web/src/infra/i18n/utils/href.ts
+++ b/web/src/infra/i18n/utils/href.ts
@@ -3,24 +3,24 @@ import { compile, match as matcher } from 'path-to-regexp';
 import { LinkProps } from 'next/link';
 import translatedPaths from '../translatedPaths';
 import { nextI18Next } from '../config';
-import NextI18Next from 'next-i18next';
 
 export const translateHref = (options: Options) => {
   if (process.env.NEXT_PUBLIC_I18N_ENABLED !== 'true') return options.href;
 
+  const addPrefix = makeAddLanguagePrefix(options.language);
   const result = getPathTranslation(options.href);
 
-  if (!result) return options.href;
+  if (!result) return addPrefix(options.href);
 
   const { pathTranslation, parsedUrl } = result;
   const localizedRoute = pathTranslation.locales[options.language];
 
-  if (!localizedRoute) return options.href;
+  if (!localizedRoute) return addPrefix(options.href);
 
   const toPath = compile(localizedRoute);
   const unprefixedHref = toPath(parsedUrl.params);
 
-  return addLanguagePrefix(nextI18Next.config, { ...options, href: unprefixedHref });
+  return addPrefix(unprefixedHref);
 };
 
 function getPathTranslation(href: LinkProps['href']) {
@@ -35,9 +35,11 @@ function getPathTranslation(href: LinkProps['href']) {
   return null;
 }
 
-function addLanguagePrefix(config: NextI18Next['config'], options: Options) {
-  const { as } = lngPathCorrector(config, { href: options.href }, options.language);
-  return as;
+function makeAddLanguagePrefix(language: Options['language']) {
+  return (href: Options['href']) => {
+    const path = lngPathCorrector(nextI18Next.config, { href }, language);
+    return path.as;
+  };
 }
 
 interface Options {

--- a/web/src/infra/i18n/utils/href.ts
+++ b/web/src/infra/i18n/utils/href.ts
@@ -1,37 +1,46 @@
+import { lngPathCorrector } from 'next-i18next/dist/commonjs/utils';
 import { compile, match as matcher } from 'path-to-regexp';
 import { LinkProps } from 'next/link';
-import { TranslatedPath } from '../translatedPaths';
+import translatedPaths from '../translatedPaths';
+import { nextI18Next } from '../config';
+import NextI18Next from 'next-i18next';
 
-export const translateHref = (options: {
-  href: LinkProps['href'];
-  language: string;
-  translatedPaths: TranslatedPath[];
-}) => {
-  const result = getPathTranslation(options);
+export const translateHref = (options: Options) => {
+  if (process.env.NEXT_PUBLIC_I18N_ENABLED !== 'true') return options.href;
 
-  if (!result) {
-    return options.href;
-  }
+  const result = getPathTranslation(options.href);
+
+  if (!result) return options.href;
 
   const { pathTranslation, parsedUrl } = result;
   const localizedRoute = pathTranslation.locales[options.language];
 
-  if (!localizedRoute) {
-    return options.href;
-  }
+  if (!localizedRoute) return options.href;
 
   const toPath = compile(localizedRoute);
-  return toPath(parsedUrl.params);
+  const unprefixedHref = toPath(parsedUrl.params);
+
+  return addLanguagePrefix(nextI18Next.config, { ...options, href: unprefixedHref });
 };
 
-function getPathTranslation(options: { href: LinkProps['href']; translatedPaths: TranslatedPath[] }) {
-  for (let i = 0; i < options.translatedPaths.length; i++) {
-    const match = matcher<{ path: string }>(options.translatedPaths[i].original);
-    const parsed = match(options.href.toString());
+function getPathTranslation(href: LinkProps['href']) {
+  for (let i = 0; i < translatedPaths.length; i++) {
+    const match = matcher<{ path: string }>(translatedPaths[i].original);
+    const parsed = match(href.toString());
     if (!parsed) {
       continue;
     }
-    return { pathTranslation: options.translatedPaths[i], parsedUrl: parsed };
+    return { pathTranslation: translatedPaths[i], parsedUrl: parsed };
   }
   return null;
+}
+
+function addLanguagePrefix(config: NextI18Next['config'], options: Options) {
+  const { as } = lngPathCorrector(config, { href: options.href }, options.language);
+  return as;
+}
+
+interface Options {
+  href: LinkProps['href'];
+  language: string;
 }

--- a/web/src/infra/i18n/utils/router.ts
+++ b/web/src/infra/i18n/utils/router.ts
@@ -15,7 +15,6 @@ function wrap(fn: RouterNavigationFunction): RouterNavigationFunction {
       translateHref({
         href: url,
         language: nextI18Next.i18n.language,
-        translatedPaths,
       }),
       as,
       options,

--- a/web/src/infra/i18n/utils/router.ts
+++ b/web/src/infra/i18n/utils/router.ts
@@ -1,5 +1,4 @@
 import { nextI18Next } from '../config';
-import translatedPaths from '../translatedPaths';
 import { TransitionOptions, Url } from '../types';
 import { translateHref } from './href';
 import { mix } from './mix';

--- a/web/src/infra/room/GameSharing.test.tsx
+++ b/web/src/infra/room/GameSharing.test.tsx
@@ -1,18 +1,23 @@
 import React from 'react';
-import { GameSharing } from './GameSharing';
+import { GameSharingInternal as GameSharing } from './GameSharing';
 import { render, fireEvent, RenderResult, cleanup } from '@testing-library/react';
+import { I18n } from 'next-i18next';
+import { mock } from 'jest-mock-extended';
 require('@testing-library/jest-dom/extend-expect');
 
 const GAME_LINK = 'http://localhost/room/fooroom';
 
+const i18n = mock<I18n>({ language: 'en' });
+
 afterEach(cleanup);
+
 describe('GameSharing', () => {
   let wrapper: RenderResult;
   beforeEach(() => {
     window.location.assign = jest.fn();
     window.open = jest.fn();
     window.alert = jest.fn();
-    wrapper = render(<GameSharing gameCode={'foogame'} roomID={'fooroom'} isPublic={false} />);
+    wrapper = render(<GameSharing i18n={i18n} gameCode={'foogame'} roomID={'fooroom'} isPublic={false} />);
   });
 
   it('should render', () => {

--- a/web/src/infra/room/GameSharing.tsx
+++ b/web/src/infra/room/GameSharing.tsx
@@ -18,7 +18,7 @@ import { createMuiTheme, MuiThemeProvider } from '@material-ui/core/styles';
 import { QrCodePopup } from './QrCodePopup';
 import { lightGreen } from '@material-ui/core/colors';
 import { shortIdToAnimal } from '../lobby/LobbyUtil';
-import { translateHref, withTranslation, WithTranslation, nextI18Next } from 'infra/i18n';
+import { translateHref, withTranslation, WithTranslation } from 'infra/i18n';
 import { compose } from 'recompose';
 
 const theme = createMuiTheme({

--- a/web/src/infra/room/GameSharing.tsx
+++ b/web/src/infra/room/GameSharing.tsx
@@ -18,6 +18,8 @@ import { createMuiTheme, MuiThemeProvider } from '@material-ui/core/styles';
 import { QrCodePopup } from './QrCodePopup';
 import { lightGreen } from '@material-ui/core/colors';
 import { shortIdToAnimal } from '../lobby/LobbyUtil';
+import { translateHref, withTranslation, WithTranslation, nextI18Next } from 'infra/i18n';
+import { compose } from 'recompose';
 
 const theme = createMuiTheme({
   palette: {
@@ -25,7 +27,9 @@ const theme = createMuiTheme({
   },
 });
 
-interface IGameSharingProps {
+interface IGameSharingInnerProps extends Pick<WithTranslation, 'i18n'> {}
+
+interface IGameSharingOutterProps {
   gameCode: string;
   roomID: string;
   isPublic: boolean;
@@ -36,12 +40,11 @@ interface IGameSharingState {
   copyButtonRecentlyPressed: boolean;
 }
 
-export class GameSharing extends React.Component<IGameSharingProps, IGameSharingState> {
+export class GameSharingInternal extends React.Component<
+  IGameSharingInnerProps & IGameSharingOutterProps,
+  IGameSharingState
+> {
   state: IGameSharingState = { showingQrCode: false, copyButtonRecentlyPressed: false };
-
-  constructor(props: any) {
-    super(props);
-  }
 
   render() {
     let copyButtonColor;
@@ -165,6 +168,11 @@ export class GameSharing extends React.Component<IGameSharingProps, IGameSharing
   _getLink = () => {
     const origin = window.location.origin;
     const roomID = this.props.roomID;
-    return `${origin}/room/${roomID}`;
+    const href = translateHref({ href: `/room/${roomID}`, language: this.props.i18n.language });
+    return `${origin}${href}`;
   };
 }
+
+const enhance = compose<IGameSharingInnerProps, IGameSharingOutterProps>(withTranslation());
+
+export const GameSharing = enhance(GameSharingInternal);

--- a/web/src/infra/room/GameSharing.tsx
+++ b/web/src/infra/room/GameSharing.tsx
@@ -18,7 +18,7 @@ import { createMuiTheme, MuiThemeProvider } from '@material-ui/core/styles';
 import { QrCodePopup } from './QrCodePopup';
 import { lightGreen } from '@material-ui/core/colors';
 import { shortIdToAnimal } from '../lobby/LobbyUtil';
-import { translateHref, withTranslation, WithTranslation } from 'infra/i18n';
+import { nextI18Next, translateHref, withTranslation, WithTranslation } from 'infra/i18n';
 import { compose } from 'recompose';
 
 const theme = createMuiTheme({
@@ -168,8 +168,8 @@ export class GameSharingInternal extends React.Component<
   _getLink = () => {
     const origin = window.location.origin;
     const roomID = this.props.roomID;
-    const href = translateHref({ href: `/room/${roomID}`, language: this.props.i18n.language });
-    return `${origin}${href}`;
+    const href = translateHref({ href: `/room/${roomID}`, language: nextI18Next.i18n.language });
+    return new URL(href, origin).toString();
   };
 }
 

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -11,7 +11,7 @@ import UaContext from 'infra/common/device/IsMobileContext';
 import withError from 'next-with-error';
 import ErrorPage from './_error';
 import ReactGA from 'react-ga';
-import Router from 'next/router';
+import { Router } from 'infra/i18n';
 import * as Sentry from '@sentry/browser';
 
 import { wrapper } from 'infra/common/redux/store';
@@ -62,7 +62,7 @@ const client = new ApolloClient({
   cache: new InMemoryCache(),
 });
 
-class defaultApp extends App {
+class DefaultApp extends App {
   logPageView(path: string) {
     ReactGA.set({ page: path });
     ReactGA.pageview(path);
@@ -85,12 +85,14 @@ class defaultApp extends App {
       if (version && channel) release = `${version}-${channel}`;
       Sentry.init({ dsn: SENTRY_DSN, release });
     }
-    // https://github.com/sergiodxa/next-ga/blob/32899e9635efe1491a5f47469b0bd2250e496f99/src/index.js#L32
-    (Router as any).onRouteChangeComplete = (path: string) => {
-      this.logPageView(path);
-    };
+    Router.events.on('routeChangeComplete', this.logPageView);
     this.logPageView(window.location.pathname);
   }
+
+  componentWillUnmount() {
+    Router.events.off('routeChangeComplete', this.logPageView);
+  }
+
   render() {
     const { Component, pageProps, isMobile } = this.props as any;
     return (
@@ -132,4 +134,4 @@ class defaultApp extends App {
 
 const enhance = compose(wrapper.withRedux, appWithTranslation, withError(ErrorPage));
 
-export default enhance(defaultApp);
+export default enhance(DefaultApp);

--- a/web/src/pages/about.tsx
+++ b/web/src/pages/about.tsx
@@ -9,7 +9,7 @@ import Typography from '@material-ui/core/Typography';
 import FreeBoardGamesBar from 'infra/common/components/base/FreeBoardGamesBar';
 import SEO from 'infra/common/helpers/SEO';
 import Breadcrumbs from 'infra/common/helpers/Breadcrumbs';
-import { useRouter } from 'next/router';
+import { useRouter } from 'infra/i18n';
 import { GAMES_LIST } from 'games';
 import { IGameStatus } from 'gamesShared/definitions/game';
 import ListItemAvatar from '@material-ui/core/ListItemAvatar';

--- a/web/src/pages/g/[gameCode]/index.tsx
+++ b/web/src/pages/g/[gameCode]/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Router from 'next/router';
+import { Router } from 'infra/i18n';
 import { IGameDef } from 'gamesShared/definitions/game';
 import { GAMES_MAP } from 'games';
 import { generatePageError } from 'next-with-error';

--- a/web/src/pages/g/[gameCode]/index.tsx
+++ b/web/src/pages/g/[gameCode]/index.tsx
@@ -4,7 +4,7 @@ import { IGameDef } from 'gamesShared/definitions/game';
 import { GAMES_MAP } from 'games';
 import { generatePageError } from 'next-with-error';
 
-export default class extends React.Component {
+export default class G extends React.Component {
   static async getInitialProps({ res, query }) {
     const gameCode = query.gameCode as string;
     const gameDef: IGameDef = GAMES_MAP[gameCode];

--- a/web/src/pages/match/[matchId]/index.tsx
+++ b/web/src/pages/match/[matchId]/index.tsx
@@ -1,10 +1,23 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
 import getMessagePage from 'infra/common/components/alert/MessagePage';
+import { NextPage } from 'next';
 
 const LoadingPage = getMessagePage('loading', 'Loading...');
 
-export default dynamic(import('../../../infra/game/Match'), {
+const GameMatch = dynamic(() => import('infra/game/Match'), {
   ssr: false,
-  loading: () => <LoadingPage />,
+  loading: LoadingPage,
 });
+
+const Match: NextPage = () => {
+  return <GameMatch />;
+};
+
+Match.getInitialProps = () => {
+  return {
+    namespacesRequired: [],
+  };
+};
+
+export default Match;

--- a/web/src/pages/play/index.tsx
+++ b/web/src/pages/play/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Router from 'next/router';
+import { Router } from 'infra/i18n';
 
 export default class extends React.Component {
   static async getInitialProps({ res }) {

--- a/web/src/pages/play/index.tsx
+++ b/web/src/pages/play/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Router } from 'infra/i18n';
 
-export default class extends React.Component {
+export default class Play extends React.Component {
   static async getInitialProps({ res }) {
     const redirectTo = '/';
     if (res) {

--- a/web/src/pages/room/[roomID]/[catchAll]/index.tsx
+++ b/web/src/pages/room/[roomID]/[catchAll]/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Router from 'next/router';
+import { Router } from 'infra/i18n';
 import { IGameDef } from 'gamesShared/definitions/game';
 import { GAMES_MAP } from 'games';
 import { generatePageError } from 'next-with-error';

--- a/web/src/pages/room/[roomID]/[catchAll]/index.tsx
+++ b/web/src/pages/room/[roomID]/[catchAll]/index.tsx
@@ -4,7 +4,7 @@ import { IGameDef } from 'gamesShared/definitions/game';
 import { GAMES_MAP } from 'games';
 import { generatePageError } from 'next-with-error';
 
-export default class extends React.Component {
+export default class LegacyRoom extends React.Component {
   static async getInitialProps({ res, query }) {
     // our old URL scheme had the gameCode in place of the roomID, so capture that:
     const gameCode = query.roomID as string;

--- a/web/src/pages/room/[roomID]/index.tsx
+++ b/web/src/pages/room/[roomID]/index.tsx
@@ -1,10 +1,23 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
 import getMessagePage from 'infra/common/components/alert/MessagePage';
+import { NextPage } from 'next';
 
 const LoadingPage = getMessagePage('loading', 'Loading...');
 
-export default dynamic(import('../../../infra/room/Room'), {
+const DynamicRoom = dynamic(() => import('infra/room/Room'), {
   ssr: false,
-  loading: () => <LoadingPage />,
+  loading: LoadingPage,
 });
+
+const Room: NextPage = () => {
+  return <DynamicRoom />;
+};
+
+Room.getInitialProps = () => {
+  return {
+    namespacesRequired: [],
+  };
+};
+
+export default Room;


### PR DESCRIPTION
### Goals

- Replace next/router for infra/i18n for some redirects on /play, /room, /g.
- Replace next/router for infra/i18n for SEO Breadcrumbs (because of pathname).
- Replace onRouteChangeComplete for a subscription of a listener on a specific event: `routeChangeComplete` (see https://stackoverflow.com/a/53933774).
- Translate shareable room link by making `translateHref` function also call `lngPathCorrector` - which is an internal function from next-i18next.

These changes should finish all required changes to make navigation compliant to i18n :tada: