### PR TITLE
[i18n] Game translation structure

### DIFF
--- a/web/jest.config.js
+++ b/web/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   rootDir: 'src/',
   roots: ['<rootDir>', '<rootDir>/../server'],
   testPathIgnorePatterns: ['.next/', 'node_modules/'],
-  setupFilesAfterEnv: ['../jest.setup.ts'],
+  setupFilesAfterEnv: ['../jest.setup.defineProperty.ts', '../jest.setup.ts'],
   transform: {
     '^.+\\.[t|j]sx?$': 'babel-jest',
   },

--- a/web/jest.setup.defineProperty.ts
+++ b/web/jest.setup.defineProperty.ts
@@ -1,0 +1,15 @@
+// prevent object freezing - fixes an issue with disabling the zone.js definePropety patch
+// https://github.com/facebook/jest/issues/6914#issuecomment-654710111
+const { defineProperty } = Object;
+
+Object.defineProperty = (object, name, meta) => {
+  if (meta.get && !meta.configurable) {
+    return defineProperty(object, name, {
+      ...meta,
+      configurable: true,
+    });
+  }
+  return defineProperty(object, name, meta);
+};
+
+export {};

--- a/web/package.json
+++ b/web/package.json
@@ -43,7 +43,8 @@
     "prereport:combined": "yarn run combine:reports",
     "report:combined": "nyc report --reporter lcov --report-dir coverage",
     "storybook": "cross-env NODE_PATH=src/ NODE_OPTIONS='--max-old-space-size=4096' start-storybook -p 6006",
-    "prepare": "cd .. && husky install web/.husky"
+    "prepare": "cd .. && husky install web/.husky",
+    "gen:games": "cd .. && yarn run gen:games"
   },
   "dependencies": {
     "@apollo/react-components": "^4.0.0",

--- a/web/public/static/locales/en/GameCard.json
+++ b/web/public/static/locales/en/GameCard.json
@@ -1,0 +1,3 @@
+{
+  "play": "Play {{name}}"
+}

--- a/web/public/static/locales/en/GameInfo.json
+++ b/web/public/static/locales/en/GameInfo.json
@@ -1,0 +1,4 @@
+{
+  "breadcrumb": "Play",
+  "play": "Play {{name}}"
+}

--- a/web/public/static/locales/en/chess.json
+++ b/web/public/static/locales/en/chess.json
@@ -1,0 +1,8 @@
+{
+  "name": "Chess",
+  "description": "International Rules",
+  "instructions": {
+    "videoId": "fKxG8KjH1Qg",
+    "text": "Chess is a board game for two players. It is played in a square board, made of 64 smaller squares, with eight squares on each side.\n\nEach player starts with sixteen pieces: eight pawns, two knights, two bishops, two rooks, one queen and one king. The player with white pieces always makes the first move.\n\nThe goal of the game is for each player to try and checkmate the king of the opponent.\nCheckmate is a game position in which a player's king is threatened with capture and there is no way to remove the threat. Checkmating the opponent wins the game.\n\n[Click here for the allowed moves of each piece.](https://www.chessusa.com/chess-rules.html)\n"
+  }
+}

--- a/web/public/static/locales/pt/GameCard.json
+++ b/web/public/static/locales/pt/GameCard.json
@@ -1,0 +1,3 @@
+{
+  "play": "Jogar {{name}}"
+}

--- a/web/public/static/locales/pt/GameInfo.json
+++ b/web/public/static/locales/pt/GameInfo.json
@@ -1,0 +1,4 @@
+{
+  "breadcrumb": "Jogar",
+  "play": "Jogar {{name}}"
+}

--- a/web/public/static/locales/pt/chess.json
+++ b/web/public/static/locales/pt/chess.json
@@ -1,0 +1,8 @@
+{
+  "name": "Xadrez",
+  "description": "Regras internacionais",
+  "instructions": {
+    "videoId": "fKxG8KjH1Qg",
+    "text": "Xadrez é um jogo de tabuleiro para duas pessoas. É jogado em um tabuleiro quadrado, contendo 64 quadrados menores, com oito quadrados de cada lado.\n\nCada pessoa começa com dezesseis peças: oito peões, dois cavalos, dois bispos, duas torres, uma dama e um rei. A pessoa com as peças brancas sempre faz a primeira jogada.\n\nO objetivo do jogo é que cada pessoa tente e aplique um xeque-mate no rei do oponente.\nO xeque-mate é uma posição de jogo ao qual o rei de um jogador é ameaçado de ser capturado e não existe forma de livrar-se da ameaça. Quem conseguir aplicar um xeque-mate no oponente ganha o jogo.\n\n[Clique aqui para ver os movimentos permitidos para cada peça.](https://www.chessusa.com/chess-rules.html)\n"
+  }
+}

--- a/web/server/sitemap/sitemap.test.ts
+++ b/web/server/sitemap/sitemap.test.ts
@@ -29,24 +29,25 @@ describe('generateSiteMapXML', () => {
   });
 
   it('should generate sitemap with i18n disabled', () => {
+    const restore = mockedEnv({ NEXT_PUBLIC_I18N_ENABLED: 'false' });
     generateSiteMapXML({
       manifest: manifestFixture(),
       staticDir: staticDirFixture(),
       host: hostFixture(),
     });
     expect(writeFileSync).toHaveBeenCalledWith(expect.any(String), sitemapFixture);
+    restore();
   });
 
   it('should generate sitemap with i18n enabled', () => {
-    process.env = Object.assign(process.env, {
-      NEXT_PUBLIC_I18N_ENABLED: 'true',
-    });
+    const restore = mockedEnv({ NEXT_PUBLIC_I18N_ENABLED: 'true' });
     generateSiteMapXML({
       manifest: manifestFixture(),
       staticDir: staticDirFixture(),
       host: hostFixture(),
     });
     expect(writeFileSync).toHaveBeenCalledWith(expect.any(String), sitemapI18nFixture);
+    restore();
   });
 });
 

--- a/web/src/gamesShared/components/fbg/GameLayout.test.tsx
+++ b/web/src/gamesShared/components/fbg/GameLayout.test.tsx
@@ -5,13 +5,27 @@ import { IGameArgs } from 'gamesShared/definitions/game';
 import { GameMode } from 'gamesShared/definitions/mode';
 import { LobbyService } from '../../../infra/common/services/LobbyService';
 import ReplayIcon from '@material-ui/icons/Replay';
-import Router from 'next/router';
+import { Router } from 'infra/i18n';
 
 beforeEach(() => {
   jest.clearAllMocks();
 });
 
 describe('ReplayIcon', () => {
+  let querySpy: jest.SpyInstance<typeof Router['query']>;
+
+  beforeEach(() => {
+    querySpy = jest.spyOn(Router, 'query', 'get');
+  });
+
+  beforeAll(() => {
+    jest.spyOn(Router, 'push');
+  });
+
+  afterEach(() => {
+    querySpy.mockClear();
+  });
+
   it('should show ReplayIcon for AI', () => {
     const gameArgs: IGameArgs = {
       gameCode: 'FooGame',
@@ -34,7 +48,8 @@ describe('ReplayIcon', () => {
   });
 
   it('should redirect to room returned by play again endpoint', async () => {
-    Router.query = { matchId: 'roomFoo' };
+    querySpy.mockReturnValue({ matchId: 'roomFoo' });
+
     const p = Promise.resolve('fooNextRoom');
     LobbyService.getPlayAgainNextRoom = jest.fn().mockReturnValue(p);
 
@@ -49,7 +64,7 @@ describe('ReplayIcon', () => {
 
     wrapper.find(ReplayIcon).simulate('click');
     await p;
-    expect(Router.push).toHaveBeenCalledWith('/room/fooNextRoom', undefined, undefined);
+    expect(Router.push).toHaveBeenCalledWith('/room/fooNextRoom');
   });
 
   it('should call Router.push with window.location.pathname', () => {
@@ -59,6 +74,6 @@ describe('ReplayIcon', () => {
     };
     const wrapper = mount(<GameLayout gameOver={'Foo Won'} gameArgs={gameArgs} />);
     wrapper.find(ReplayIcon).simulate('click');
-    expect(Router.push).toHaveBeenCalledWith(window.location.pathname, undefined, undefined);
+    expect(Router.push).toHaveBeenCalledWith(window.location.pathname);
   });
 });

--- a/web/src/infra/common/components/game/GameCard.tsx
+++ b/web/src/infra/common/components/game/GameCard.tsx
@@ -3,14 +3,20 @@ import { IGameDef } from 'gamesShared/definitions/game';
 import IconButton from '@material-ui/core/IconButton';
 import NavigateNextIcon from '@material-ui/icons/NavigateNext';
 import Typography from '@material-ui/core/Typography';
+import { WithNamedT, withNamedT, WithTranslation, withTranslation } from 'infra/i18n';
+import { compose } from 'recompose';
 
-interface IGameCardProps {
+interface IGameCardInnerProps extends Pick<WithTranslation, 't'>, WithNamedT {}
+
+interface IGameCardOutterProps {
   game: IGameDef;
   isLink?: boolean;
 }
 
-export class GameCard extends React.Component<IGameCardProps, {}> {
+export class GameCardInternal extends React.Component<IGameCardInnerProps & IGameCardOutterProps, {}> {
   render() {
+    const { t, translate } = this.props;
+
     let navigateButton = null;
     const image = this.props.game.imageURL;
     const mainDivStyle: React.CSSProperties = {
@@ -51,11 +57,11 @@ export class GameCard extends React.Component<IGameCardProps, {}> {
     }
     const gameNameHeading = this.props.isLink ? (
       <Typography gutterBottom={false} variant="h4" component="h2" style={{ fontWeight: 300 }}>
-        {`Play ${this.props.game.name}`}
+        {t('play', { name: translate('name', this.props.game.name) })}
       </Typography>
     ) : (
       <Typography gutterBottom={false} variant="h4" component="h1" style={{ fontWeight: 300 }}>
-        {this.props.game.name}
+        {translate('name', this.props.game.name)}
       </Typography>
     );
     return (
@@ -79,7 +85,7 @@ export class GameCard extends React.Component<IGameCardProps, {}> {
           }}
         >
           <Typography gutterBottom={false} variant="overline" component="h5">
-            {this.props.game.description}
+            {translate('description', this.props.game.description)}
           </Typography>
         </div>
         {navigateButton}
@@ -87,3 +93,10 @@ export class GameCard extends React.Component<IGameCardProps, {}> {
     );
   }
 }
+
+const enhance = compose<IGameCardInnerProps, IGameCardOutterProps>(
+  withTranslation('GameCard'),
+  withNamedT<IGameCardOutterProps>(({ game }) => game.code),
+);
+
+export const GameCard = enhance(GameCardInternal);

--- a/web/src/infra/common/components/game/GameCard.tsx
+++ b/web/src/infra/common/components/game/GameCard.tsx
@@ -3,10 +3,10 @@ import { IGameDef } from 'gamesShared/definitions/game';
 import IconButton from '@material-ui/core/IconButton';
 import NavigateNextIcon from '@material-ui/icons/NavigateNext';
 import Typography from '@material-ui/core/Typography';
-import { WithNamedT, withNamedT, WithTranslation, withTranslation } from 'infra/i18n';
+import { WithTranslate, withTranslate, WithTranslation, withTranslation } from 'infra/i18n';
 import { compose } from 'recompose';
 
-interface IGameCardInnerProps extends Pick<WithTranslation, 't'>, WithNamedT {}
+interface IGameCardInnerProps extends Pick<WithTranslation, 't'>, WithTranslate {}
 
 interface IGameCardOutterProps {
   game: IGameDef;
@@ -94,9 +94,6 @@ export class GameCardInternal extends React.Component<IGameCardInnerProps & IGam
   }
 }
 
-const enhance = compose<IGameCardInnerProps, IGameCardOutterProps>(
-  withTranslation('GameCard'),
-  withNamedT<IGameCardOutterProps>(({ game }) => game.code),
-);
+const enhance = compose<IGameCardInnerProps, IGameCardOutterProps>(withTranslation('GameCard'), withTranslate());
 
 export const GameCard = enhance(GameCardInternal);

--- a/web/src/infra/game/GameProvider.tsx
+++ b/web/src/infra/game/GameProvider.tsx
@@ -1,0 +1,18 @@
+/* eslint-disable react/prop-types */
+import { GAMES_MAP } from 'games';
+import { IGameDef } from 'gamesShared/definitions/game';
+import { createContext, FC, useContext } from 'react';
+import React from 'react';
+
+const Context = createContext<GameContext>({} as GameContext);
+
+export const useCurrentGame = () => useContext(Context);
+
+export const GameProvider: FC<{ gameCode: string }> = ({ children, gameCode }) => {
+  return <Context.Provider value={{ game: GAMES_MAP[gameCode], gameCode }}>{children}</Context.Provider>;
+};
+
+export interface GameContext {
+  game?: IGameDef;
+  gameCode?: string;
+}

--- a/web/src/infra/gameInfo/GameInfo.tsx
+++ b/web/src/infra/gameInfo/GameInfo.tsx
@@ -12,10 +12,10 @@ import ReactMarkdown from 'react-markdown';
 import { GameInstructionsText } from 'infra/gameInfo/GameInstructionsText';
 import Breadcrumbs from 'infra/common/helpers/Breadcrumbs';
 import { GameContributors } from './GameContributors';
-import { translateHref, WithNamedT, withNamedT, withTranslation, WithTranslation } from 'infra/i18n';
+import { translateHref, WithTranslate, withTranslate, withTranslation, WithTranslation } from 'infra/i18n';
 import { compose } from 'recompose';
 
-interface GameInfoInnerProps extends Pick<WithTranslation, 't' | 'i18n'>, WithNamedT {}
+interface GameInfoInnerProps extends Pick<WithTranslation, 't' | 'i18n'>, WithTranslate {}
 
 interface GameInfoOutterProps {
   gameCode: string;
@@ -105,9 +105,6 @@ class GameInfo extends React.Component<GameInfoInnerProps & GameInfoOutterProps,
   }
 }
 
-const enhance = compose(
-  withTranslation('GameInfo'),
-  withNamedT<GameInfoOutterProps>(({ gameCode }) => gameCode),
-);
+const enhance = compose(withTranslation('GameInfo'), withTranslate());
 
 export default enhance(GameInfo);

--- a/web/src/infra/i18n/components/Link.test.tsx
+++ b/web/src/infra/i18n/components/Link.test.tsx
@@ -11,7 +11,7 @@ describe('Link', () => {
   let nextI18Next: NextI18Next;
   let Link: Link;
 
-  beforeAll(() => {
+  beforeEach(() => {
     const restore = mockedEnv({ NEXT_PUBLIC_I18N_ENABLED: 'true' });
     afterEach(restore);
   });
@@ -35,14 +35,17 @@ describe('Link', () => {
       await thenLinkShouldHave('Play bingo', { href: '/pt/jogar/bingo' });
     });
 
-    it('does not change the url on invalid languages', async () => {
-      const spy = jest.spyOn(console, 'warn').mockImplementation();
+    it('does not render Link whe using a invalid language', async () => {
+      jest.spyOn(console, 'warn').mockImplementation();
+      jest.spyOn(console, 'error').mockImplementation();
 
       await forGivenLanguage('invalid');
-      renderLink('Play chess', { href: '/play/chess' });
-      await thenLinkShouldHave('Play chess', { href: '/play/chess' });
 
-      spy.mockRestore();
+      expect(() => {
+        renderLink('Play chess', { href: '/play/chess' });
+      }).toThrow('Invalid configuration: Current language is not included in all languages array');
+
+      jest.restoreAllMocks();
     });
 
     it('does not change url for non-translated path ', async () => {

--- a/web/src/infra/i18n/hocs/index.ts
+++ b/web/src/infra/i18n/hocs/index.ts
@@ -1,3 +1,4 @@
 export * from './appWithTranslation';
+export * from './withNewT';
 export * from './withRouter';
 export * from './withTranslation';

--- a/web/src/infra/i18n/hocs/index.ts
+++ b/web/src/infra/i18n/hocs/index.ts
@@ -1,4 +1,4 @@
 export * from './appWithTranslation';
-export * from './withNewT';
 export * from './withRouter';
+export * from './withTranslate';
 export * from './withTranslation';

--- a/web/src/infra/i18n/hocs/withNewT.tsx
+++ b/web/src/infra/i18n/hocs/withNewT.tsx
@@ -1,0 +1,37 @@
+import { getDisplayName } from 'recompose';
+import { nextI18Next } from '../config';
+import React from 'react';
+
+export const withNamedT = <TOutterProps, TReturn extends string = string>(
+  codeGetter: (props: TOutterProps) => TReturn,
+  propertyName: string = 'translate',
+  options: { withRef?: boolean } = {},
+) => {
+  return function Extend(WrappedComponent) {
+    function I18nextWithTranslation({ forwardedRef, ...rest }) {
+      const ns = codeGetter(rest as TOutterProps);
+      const [t] = nextI18Next.useTranslation(ns, rest);
+
+      const passDownProps = { ...rest, [propertyName]: t };
+
+      if (options.withRef && forwardedRef) {
+        passDownProps.ref = forwardedRef;
+      } else if (!options.withRef && forwardedRef) {
+        passDownProps.forwardedRef = forwardedRef;
+      }
+
+      return React.createElement(WrappedComponent, passDownProps);
+    }
+
+    I18nextWithTranslation.displayName = `withNamedT(${getDisplayName(WrappedComponent)})`;
+    I18nextWithTranslation.WrappedComponent = WrappedComponent;
+    I18nextWithTranslation.getInitialProps = WrappedComponent.getInitialProps;
+    I18nextWithTranslation.propTypes = WrappedComponent.propTypes;
+    I18nextWithTranslation.defaultProps = WrappedComponent.defaultProps;
+
+    const forwardRef = (props, ref) =>
+      React.createElement(I18nextWithTranslation, Object.assign({}, props, { forwardedRef: ref }));
+
+    return options.withRef ? React.forwardRef(forwardRef) : I18nextWithTranslation;
+  };
+};

--- a/web/src/infra/i18n/hocs/withTranslate.tsx
+++ b/web/src/infra/i18n/hocs/withTranslate.tsx
@@ -1,15 +1,13 @@
 import { getDisplayName } from 'recompose';
 import { nextI18Next } from '../config';
 import React from 'react';
+import { useCurrentGame } from 'infra/game/GameProvider';
 
-export const withNamedT = <TOutterProps, TReturn extends string = string>(
-  codeGetter: (props: TOutterProps) => TReturn,
-  propertyName: string = 'translate',
-  options: { withRef?: boolean } = {},
-) => {
+export const withTranslate = (propertyName: string = 'translate', options: { withRef?: boolean } = {}) => {
   return function Extend(WrappedComponent) {
     function I18nextWithTranslation({ forwardedRef, ...rest }) {
-      const ns = codeGetter(rest as TOutterProps);
+      const { game } = useCurrentGame();
+      const ns = game?.code;
       const [t] = nextI18Next.useTranslation(ns, rest);
 
       const passDownProps = { ...rest, [propertyName]: t };

--- a/web/src/infra/i18n/types/index.ts
+++ b/web/src/infra/i18n/types/index.ts
@@ -11,4 +11,4 @@ export type NextRouter = Router;
 
 export type { WithRouterProps } from 'next/dist/client/with-router';
 
-export type WithNamedT<T extends string = 'translate'> = Record<T, TFunction>;
+export type WithTranslate<T extends string = 'translate'> = Record<T, TFunction>;

--- a/web/src/infra/i18n/types/index.ts
+++ b/web/src/infra/i18n/types/index.ts
@@ -1,4 +1,4 @@
-import { Router } from 'next-i18next';
+import { Router, TFunction } from 'next-i18next';
 import { UrlObject } from 'url';
 
 export type Url = UrlObject | string;
@@ -10,3 +10,5 @@ export interface TransitionOptions {
 export type NextRouter = Router;
 
 export type { WithRouterProps } from 'next/dist/client/with-router';
+
+export type WithNamedT<T extends string = 'translate'> = Record<T, TFunction>;

--- a/web/src/infra/i18n/utils/index.ts
+++ b/web/src/infra/i18n/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './href';
+export * from './mix';
 export * from './router';

--- a/web/src/infra/i18n/utils/mix.ts
+++ b/web/src/infra/i18n/utils/mix.ts
@@ -6,7 +6,9 @@ export const mix = <TOriginal extends object, TAdditional>(
   const props = Object.getOwnPropertyNames(original);
   for (const prop of props) {
     const descriptor = Object.getOwnPropertyDescriptor(original, prop);
-    Object.defineProperty(copy, prop, descriptor);
+    if (!copy.hasOwnProperty(prop)) {
+      Object.defineProperty(copy, prop, descriptor);
+    }
   }
   return copy;
 };

--- a/web/src/infra/room/GameSharing.test.tsx
+++ b/web/src/infra/room/GameSharing.test.tsx
@@ -3,6 +3,7 @@ import { GameSharingInternal as GameSharing } from './GameSharing';
 import { render, fireEvent, RenderResult, cleanup } from '@testing-library/react';
 import { I18n } from 'next-i18next';
 import { mock } from 'jest-mock-extended';
+import mockedEnv from 'mocked-env';
 require('@testing-library/jest-dom/extend-expect');
 
 const GAME_LINK = 'http://localhost/room/fooroom';
@@ -45,12 +46,25 @@ describe('GameSharing', () => {
     expect(window.open as any).toHaveBeenCalled();
   });
 
-  it('should copy link', () => {
+  it('should copy link when i18n is disabled', () => {
+    const restore = mockedEnv({ NEXT_PUBLIC_I18N_ENABLED: 'false' });
     jest.useFakeTimers();
     const button = wrapper.getByLabelText('Copy');
     fireEvent.click(button);
     expect(wrapper.getByText('Copied!')).toBeInTheDocument();
     jest.runAllTimers();
     expect((window as any).copyClipboardMock).toHaveBeenCalledWith(GAME_LINK);
+    restore();
+  });
+
+  it('should copy link when i18n is enabled', () => {
+    const restore = mockedEnv({ NEXT_PUBLIC_I18N_ENABLED: 'true' });
+    jest.useFakeTimers();
+    const button = wrapper.getByLabelText('Copy');
+    fireEvent.click(button);
+    expect(wrapper.getByText('Copied!')).toBeInTheDocument();
+    jest.runAllTimers();
+    expect((window as any).copyClipboardMock).toHaveBeenCalledWith(GAME_LINK);
+    restore();
   });
 });

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -23,6 +23,7 @@ import { ApolloProvider } from '@apollo/react-hooks';
 import AddressHelper from 'infra/common/helpers/AddressHelper';
 import { compose } from 'recompose';
 import { appWithTranslation } from 'infra/i18n';
+import { GameProvider } from 'infra/game/GameProvider';
 
 const GA_TRACKING_CODE = 'UA-105391878-2';
 const SENTRY_DSN = 'https://5957292e58cf4d2fbb781910e7b26b1f@o397015.ingest.sentry.io/5251165';
@@ -85,7 +86,9 @@ class DefaultApp extends App {
       if (version && channel) release = `${version}-${channel}`;
       Sentry.init({ dsn: SENTRY_DSN, release });
     }
+
     Router.events.on('routeChangeComplete', this.logPageView);
+
     this.logPageView(window.location.pathname);
   }
 
@@ -113,13 +116,16 @@ class DefaultApp extends App {
           <SelfXSSWarning />
           <UaContext.Provider value={isMobile}>
             <ApolloProvider client={client}>
-              <Component {...pageProps} />
+              <GameProvider gameCode={this.props.pageProps.gameCode}>
+                <Component {...pageProps} />
+              </GameProvider>
             </ApolloProvider>
           </UaContext.Provider>
         </ThemeProvider>
       </>
     );
   }
+
   static async getInitialProps({ Component, ctx }) {
     let pageProps = {};
 


### PR DESCRIPTION
### Goals

Propose a game translation structure, which provides a way to translate the game definition (name, description, text instructions, and video id instructions). The game code is not being translated here yet.

#### Proposal

- Each game has a file named with its code (e.g. `public/static/locales/en/chess.json`) - each language needs a file like this one.
- In case of a game does not have a translating file, it will fallback for the content located where the game is defined (e.g. `src/games/chess/index.ts`).
- `withTranslate` is a decorator which knows how to translate string which are specific for a game (not only its definitions). The game is obtained from pages where `gameCode` is a path param. Also, on those pages and inner components, you could use `useCurrentGame` to have access to the `gameDef` instance.
- Inside a component:
  - if you need to translate something related to the infra (e.g. Play label) you should use the `t` function which is injected by `withTranslation` HOC.  Extend your component props with `WithTranslation` (or maybe `Pick<WithTranslation, 't'>` type for better typing.
  - But if you need to translate something that is strictly related to the game (e.g. Chess) you should use `withTranslate`, which injects a `translate` function. Extend your component props with `WithTranslate` type for better typing.
  - Why? `withTranslate` is a copy of `withTranslation` which already selects the game namespace for translation (e.g. `public/static/locales/en/chess.json`).
- As you may have noticed, once a game is translated, the `IGameDef` instance won't need name, descriptions, and instructions properties anymore. But right now, these values serve as a fallback for untranslated games.

#### Other stuff

There are other minor changes made here:
- Adding a node script to run `gen:games` from web folder
- Making sure env (NEXT_PUBLIC_I18N_ENABLED) is defined on each test (to prevent side effects if the variable is already defined somewhere else)