### PR TITLE
[i18n] Deprecate render methods used by customizations

### DIFF
--- a/web/src/gamesShared/definitions/customization.ts
+++ b/web/src/gamesShared/definitions/customization.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ComponentType } from 'react';
 import { GameMode } from './mode';
 
 export enum CustomizationType {
@@ -23,7 +23,15 @@ export interface GameCustomizationProps {
   onChange: (result: unknown) => void;
 }
 
-export interface GameCustomization {
+export interface GameCustomization<
+  TQuickCustomizationProps extends GameCustomizationProps = GameCustomizationProps,
+  TFullCustomizationProps extends GameCustomizationProps = GameCustomizationProps
+> {
+  /** @deprecated */
   renderQuick?: (args: GameCustomizationProps) => React.ReactNode;
+  /** @deprecated */
   renderFull?: (args: GameCustomizationProps) => React.ReactNode;
+
+  QuickCustomization?: ComponentType<TQuickCustomizationProps>;
+  FullCustomization?: ComponentType<TFullCustomizationProps>;
 }

--- a/web/src/infra/settings/CustomizationBar.tsx
+++ b/web/src/infra/settings/CustomizationBar.tsx
@@ -37,7 +37,7 @@ export class CustomizationBarInternal extends React.Component<
   CustomizationBarInnerProps & CustomizationBarOutterProps,
   CustomizationBarState
 > {
-  state = {
+  state: CustomizationBarState = {
     showCustomizationDialog: false,
     customization: null,
     customizationState: {} as FullGameCustomizationState,
@@ -67,29 +67,37 @@ export class CustomizationBarInternal extends React.Component<
 
   private renderQuickCustomization() {
     const custom = this.state.customization;
-    if (!custom || !custom.renderQuick) {
+
+    if (!custom?.QuickCustomization && /** @deprecated */ !custom?.renderQuick) {
       return null;
     }
+
+    const { QuickCustomization } = custom;
     const mode = this.props.info.mode;
-    return custom.renderQuick({
+
+    const props = {
       mode,
       currentValue: (this.state.customizationState || {})[mode]?.quick,
       onChange: this._changeCustomValue(CustomizationType.QUICK),
-    });
+    };
+
+    return QuickCustomization ? <QuickCustomization {...props} /> : custom.renderQuick(props);
   }
 
   private hasFullCustomization() {
     const mode = this.props.info.mode;
     const custom = this.state.customization;
-    if (!custom?.renderFull) {
+    if (!custom?.FullCustomization && /** @deprecated */ !custom?.renderFull) {
       return false;
     }
-    const fullCustom = custom.renderFull({
+
+    const props = {
       mode: this.props.info.mode,
       currentValue: this.state.customizationState[mode]?.quick,
       onChange: () => {},
-    });
-    return fullCustom !== null;
+    };
+
+    return custom.FullCustomization || custom.renderFull(props) !== null;
   }
 
   private renderFullCustomizationButton() {
@@ -124,12 +132,14 @@ export class CustomizationBarInternal extends React.Component<
 
   private renderCustomizationDialogContent() {
     const custom = this.state.customization;
+    const { FullCustomization } = custom;
     const mode = this.props.info.mode;
-    return custom.renderFull({
+    const props = {
       mode: this.props.info.mode,
       currentValue: this.state.customizationState[mode]?.full,
       onChange: this._changeCustomValue(CustomizationType.FULL),
-    });
+    };
+    return FullCustomization ? <FullCustomization {...props} /> : custom.renderFull(props);
   }
 
   private renderCustomizationDialogHeader() {


### PR DESCRIPTION
The proposal here is to deprecate `renderQuick` and `renderFull`, used by customization. 

**Why?** Currently, it isn't possible to use hooks or HOCs directly inside those render methods because they are not components, only returns React elements. As an alternative, a second component that wraps everything returned by a render method would be necessary. Using a `useCurrentGameTranslation` or `withCurrentGameTranslation` is necessary to translate customization, like [this one](https://github.com/freeboardgames/FreeBoardGames.org/blob/137424c4d24f28d1e6bddce7a51975f2c47b3480/web/src/games/tictactoeplus/customization.tsx#L25).

**What is coming in?** I'm proposing that a component (or multiple) be provided as customization. The signature is pretty similar, but by letting React handle the components it allows to properly use HOC or hooks.

**What is next?** Change all places that implement a render method for customization.

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] I've read and agree with the [contribution guidelines](https://www.freeboardgames.org/docs/?path=/story/documentation-contributing--page).
