### PR TITLE
Correct bug in gameplay of Nine Men's Morris.

### DIFF
--- a/web/src/games/ninemensmorris/game.ts
+++ b/web/src/games/ninemensmorris/game.ts
@@ -90,8 +90,8 @@ export function placePiece(G: IG, ctx: Ctx, position: number): IG | string {
 
 export function movePiece(G: IG, ctx: Ctx, position: number, newPosition: number): IG | string {
   if (
-    G.points[position].piece === null ||
-    G.points[position].piece.player !== ctx.playerID || // Check if player owns this piece // Check if piece exists
+    G.points[position].piece === null || // Check if piece exists
+    G.points[position].piece.player !== ctx.playerID || // Check if player owns this piece
     G.points[newPosition].piece !== null || // Check if point isn't already occupied
     G.haveToRemovePiece || // Check if player has to remove piece
     (!G.points[position].connections.includes(newPosition) && // Check if connection exists
@@ -134,8 +134,8 @@ export function removePiece(G: IG, ctx: Ctx, position: number) {
     (G.mills
       .map((mill, index) => ({ owner: mill, index }))
       .filter((mill) => mill.owner !== null && mill.owner !== ctx.playerID)
-      .some((mill) => millsPositions[mill.index].includes(position)) &&
-      isTherePieceOutsideMill(G, ctx))
+      .some((mill) => millsPositions[mill.index].includes(position)) && // Check if piece is in opponent's mill
+      isTherePieceOutsideMill(G, ctx)) // Ignore the check if all of opponent's pieces are in mills
   ) {
     return INVALID_MOVE;
   }

--- a/web/src/games/ninemensmorris/game.ts
+++ b/web/src/games/ninemensmorris/game.ts
@@ -178,7 +178,7 @@ const GameConfig: Game<IG> = {
     Place: {
       moves: { placePiece, removePiece },
       next: Phase.Move,
-      endIf: (G: IG) => G.piecesPlaced === 18,
+      endIf: (G: IG) => G.piecesPlaced === 18 && !G.haveToRemovePiece,
       start: true,
     },
     Move: {


### PR DESCRIPTION
Don't end the placement phase if a player has to remove a piece. The consequence of this bug is that control switches players too early when a mill is formed in the final turn of the placement phase. Hence, the wrong player's piece is removed.

Improve comments for Nine Men's Morris.

#### Discussion

This pertains to #901. It is a conservative change, but I am skeptical that it fully addresses the issue since the placement phase also ends too early, and control incorrectly switches players if the 17th piece to be placed creates a mill.

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] I've read and agree with the [contribution guidelines](https://www.freeboardgames.org/docs/?path=/story/documentation-contributing--page).