### PR TITLE
GameDarkSublayout: maxWidth and vertical centering

### DIFF
--- a/web/src/games/bombsAndBunnies/board.tsx
+++ b/web/src/games/bombsAndBunnies/board.tsx
@@ -62,7 +62,7 @@ export class BgioBoard extends React.Component<IBgioBoardProps, {}> {
     }
 
     return (
-      <GameLayout gameArgs={this.props.gameArgs} allowWiderScreen={true}>
+      <GameLayout gameArgs={this.props.gameArgs} maxWidth="1000px">
         <Board {...this.getBoardProps()} />
       </GameLayout>
     );

--- a/web/src/games/estatebuyer/board.tsx
+++ b/web/src/games/estatebuyer/board.tsx
@@ -52,7 +52,7 @@ export class Board extends React.Component<IBoardProps, { gameOverPrepared: numb
     }
 
     return (
-      <GameLayout gameArgs={this.props.gameArgs} allowWiderScreen={true}>
+      <GameLayout gameArgs={this.props.gameArgs} maxWidth="1000px">
         <div className={css.board}>
           <PlayerBadges
             players={this.props.G.players}

--- a/web/src/games/frenchTarot/board.tsx
+++ b/web/src/games/frenchTarot/board.tsx
@@ -38,7 +38,7 @@ export class BgioBoard extends React.Component<
         : null;
 
     return (
-      <GameLayout gameArgs={this.props.gameArgs} allowWiderScreen={true}>
+      <GameLayout gameArgs={this.props.gameArgs} maxWidth="1000px">
         <Board
           player={player}
           players={G.players}

--- a/web/src/games/mergers/board.tsx
+++ b/web/src/games/mergers/board.tsx
@@ -175,7 +175,7 @@ export class Board extends React.Component<BoardProps, BoardState> {
   render() {
     const hotels = new Hotels(this.props.G.hotels);
     return (
-      <GameLayout allowWiderScreen={true} gameArgs={this.props.gameArgs}>
+      <GameLayout maxWidth="1000px" gameArgs={this.props.gameArgs}>
         <ThemeProvider theme={createMuiTheme({ palette: { type: 'dark' } })}>
           <MergersGameStatus
             hotels={hotels}

--- a/web/src/games/secretcodes/board.tsx
+++ b/web/src/games/secretcodes/board.tsx
@@ -78,7 +78,7 @@ export function Board({ G, ctx, moves, events, playerID, gameArgs, isActive }: I
     content = _renderPlayBoard();
   }
   return (
-    <GameLayout gameArgs={gameArgs} allowWiderScreen={true}>
+    <GameLayout gameArgs={gameArgs} maxWidth="1000px">
       {content}
     </GameLayout>
   );

--- a/web/src/games/takesix/board.tsx
+++ b/web/src/games/takesix/board.tsx
@@ -105,7 +105,7 @@ export class BoardInternal extends React.Component<IBoardInnerProps & IBoardOutt
     }
 
     return (
-      <GameLayout gameArgs={this.props.gameArgs} allowWiderScreen={true}>
+      <GameLayout gameArgs={this.props.gameArgs} maxWidth="1000px">
         <Typography variant="h5" style={{ textAlign: 'center', color: 'white', marginBottom: '16px' }}>
           {this._getStatus()}
         </Typography>

--- a/web/src/games/zooparade/board.module.css
+++ b/web/src/games/zooparade/board.module.css
@@ -25,11 +25,10 @@
 }
 
 .wrapper {
-  max-height: 100vh;
+  max-height: calc(100vh - 49px);
   overflow-y: auto;
   --info-height: 0;
   box-sizing: border-box;
-  padding: 50px 0;
 }
 
 .wrapper * {

--- a/web/src/games/zooparade/board.tsx
+++ b/web/src/games/zooparade/board.tsx
@@ -46,7 +46,7 @@ export class BoardInternal extends React.Component<IBoardInnerProps & IBoardOutt
     return (
       <>
         {this.renderNotification()}
-        <GameLayout gameArgs={this.props.gameArgs} allowWiderScreen={true} optionsMenuItems={this._getOptionsMenuItems}>
+        <GameLayout gameArgs={this.props.gameArgs} maxWidth="1000px" optionsMenuItems={this._getOptionsMenuItems}>
           {this.renderBoard()}
         </GameLayout>
       </>

--- a/web/src/gamesShared/components/fbg/GameDarkSublayout.tsx
+++ b/web/src/gamesShared/components/fbg/GameDarkSublayout.tsx
@@ -26,7 +26,7 @@ interface IGameDarkSublayoutInnerProps {
 interface IGameDarkSublayoutOutterProps {
   children: React.ReactNode;
   optionsMenuItems?: () => IOptionsItems[];
-  allowWiderScreen?: boolean;
+  maxWidth?: string;
   gameArgs: IGameArgs;
   avoidOverscrollReload?: boolean;
 }
@@ -74,7 +74,13 @@ export class GameDarkSublayoutInternal extends React.Component<IGameDarkSublayou
         <Typography
           variant="h6"
           gutterBottom={true}
-          style={{ float: 'left', marginTop: '10px', backgroundColor: 'red', color: 'white' }}
+          style={{
+            float: 'left',
+            marginTop: '10px',
+            backgroundColor: 'red',
+            color: 'white',
+            whiteSpace: 'nowrap',
+          }}
         >
           &nbsp;{gameName}&nbsp;
         </Typography>
@@ -86,7 +92,7 @@ export class GameDarkSublayoutInternal extends React.Component<IGameDarkSublayou
         <div
           style={{
             display: 'flex',
-            maxWidth: this.props.allowWiderScreen ? '1000px' : '500px',
+            maxWidth: this.props.maxWidth || '500px',
             marginLeft: 'auto',
             marginRight: 'auto',
           }}
@@ -106,14 +112,24 @@ export class GameDarkSublayoutInternal extends React.Component<IGameDarkSublayou
           style={{
             position: 'relative',
             width: '100%',
-            maxWidth: this.props.allowWiderScreen ? '1000px' : '500px',
-            color: 'white',
-            top: 'calc(50vh - 49px)',
-            left: '50%',
-            transform: 'translate(-50%, -50%)',
+            height: 'calc(100vh - 49px)',
+            textAlign: 'center',
+            lineHeight: 'calc(100vh - 49px)',
           }}
         >
-          {this.props.children}
+          <div
+            style={{
+              position: 'relative',
+              width: '100%',
+              maxWidth: this.props.maxWidth || '500px',
+              color: 'white',
+              display: 'inline-block',
+              verticalAlign: 'middle',
+              lineHeight: 'normal',
+            }}
+          >
+            {this.props.children}
+          </div>
         </div>
       </>
     );

--- a/web/src/gamesShared/components/fbg/GameLayout.tsx
+++ b/web/src/gamesShared/components/fbg/GameLayout.tsx
@@ -8,7 +8,7 @@ interface IGameLayoutProps {
   gameArgs: IGameArgs;
   children?: React.ReactNode;
   gameOver?: string;
-  allowWiderScreen?: boolean;
+  maxWidth?: string;
   avoidOverscrollReload?: boolean;
   optionsMenuItems?: () => IOptionsItems[];
   extraCardContent?: React.ReactNode;
@@ -28,7 +28,7 @@ export class GameLayout extends React.Component<IGameLayoutProps, {}> {
       return (
         <GameDarkSublayout
           optionsMenuItems={this.props.optionsMenuItems}
-          allowWiderScreen={this.props.allowWiderScreen}
+          maxWidth={this.props.maxWidth}
           avoidOverscrollReload={this.props.avoidOverscrollReload}
           gameArgs={this.props.gameArgs}
         >


### PR DESCRIPTION
#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] I've read and agree with the [contribution guidelines](https://www.freeboardgames.org/docs/?path=/story/documentation-contributing--page).

This implements the changes proposed in #922:

1. For the component `<GameLayout />`, the boolean property `allowWiderScreen` is replaced by the string property `maxWidth` so that the width can be adjusted more freely. As before, the maximum width defaults to `500px`. I modified all games that currently use the `allowWiderScreen` property so that nothing changes for them (i.e. maximum width is `1000px` in that case).
2. The vertical centering in the component `<GameDarkSublayout />` was broken, and is now fixed. The game board is still centered vertically and the average user will probably notice nothing. But when the screen height is very low, the board is prevented from overlapping on the top like in the following screenshots:
<img src="https://user-images.githubusercontent.com/1518387/128942141-09d04061-467a-4ea7-9ed8-d522bf275bd7.png" width=300 /> <img src="https://user-images.githubusercontent.com/1518387/128942231-3caf54d7-9ca1-4747-a268-20ee99a705fe.png" width=300 />
The above screenshots show the behavior *before* this PR. After this PR, the board will be rendered like below:
<img src="https://user-images.githubusercontent.com/1518387/128942577-50eacca6-fc60-47fb-95e7-52aa0fb048c3.png" width=300 /> <img src="https://user-images.githubusercontent.com/1518387/128942593-4d746263-8e34-44df-b0fd-17c75a1a3249.png" width=300 />
The lower parts of the game board can still be reached by scrolling down. Before this PR, the upper (hidden) parts of the game board could *not* be reached by scrolling or any other user interaction. So, this was actually a bug that is now fixed.

I checked all games manually for compatibility. Only the Zoo Parade needed small changes to be compatible with the fixed vertical centering because it implemented an own workaround for this bug.