### PR TITLE
Moves setActivePlayers out of endIf to onMove

### DIFF
--- a/web/src/games/secretDracula/phases/vote/phase.ts
+++ b/web/src/games/secretDracula/phases/vote/phase.ts
@@ -35,26 +35,29 @@ export let phaseVotePriest = {
       client: false,
     },
   },
-  endIf: (G: IG, ctx: Ctx) => {
-    let activePlayers = { value: {} };
-    let count = 0;
-    for (let i = 0; i < ctx.numPlayers; i++) {
-      if (G.deadIDs.includes(i)) {
-        continue;
-      } else if (G.votesYes[i] || G.votesNo[i]) {
-        // already voted
-        continue;
-      } else {
-        count += 1;
-        activePlayers.value[i] = 'phaseVotePriest';
+  turn: {
+    onMove: (G: IG, ctx: Ctx) => {
+      let activePlayers = { value: {} };
+      let count = 0;
+      for (let i = 0; i < ctx.numPlayers; i++) {
+        if (G.deadIDs.includes(i)) {
+          continue;
+        } else if (G.votesYes[i] || G.votesNo[i]) {
+          // already voted
+          continue;
+        } else {
+          count += 1;
+          activePlayers.value[i] = 'phaseVotePriest';
+        }
       }
-    }
 
-    if (count > 0) {
-      // fix for not running into Issue with no active players
-      ctx.events.setActivePlayers(activePlayers);
-    }
-
+      if (count > 0) {
+        // fix for not running into Issue with no active players
+        ctx.events.setActivePlayers(activePlayers);
+      }
+    },
+  },
+  endIf: (G: IG, ctx: Ctx) => {
     let yesVotes = G.votesYes.reduce((a, b) => {
       return b == true ? a + 1 : a;
     }, 0);


### PR DESCRIPTION
This on endIf is causing a infinite loop on newer versions of BGIO

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] I've read and agree with the [contribution guidelines](https://www.freeboardgames.org/docs/?path=/story/documentation-contributing--page).
