### PR TITLE
Removes limits from helm chart deployments

### DIFF
--- a/helm/templates/bgio-deployment.yaml
+++ b/helm/templates/bgio-deployment.yaml
@@ -49,9 +49,6 @@ spec:
           timeoutSeconds: 1
         name: bgio
         resources:
-          limits:
-            cpu: "1"
-            memory: 1024Mi
           requests:
             cpu: 100m
             memory: 128Mi

--- a/helm/templates/fbg-server-deployment.yaml
+++ b/helm/templates/fbg-server-deployment.yaml
@@ -49,9 +49,6 @@ spec:
           timeoutSeconds: 5
         name: {{ .Release.Name }}-fbg-server
         resources:
-          limits:
-            cpu: "1"
-            memory: 1024Mi
           requests:
             cpu: 100m
             memory: 128Mi

--- a/helm/templates/web-deployment.yaml
+++ b/helm/templates/web-deployment.yaml
@@ -41,9 +41,6 @@ spec:
           timeoutSeconds: 1
         name: {{ .Release.Name }}-web
         resources:
-          limits:
-            cpu: "1" 
-            memory: 1024Mi
           requests:
             cpu: 100m
             memory: 128Mi

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -22,10 +22,6 @@ postgresql:
     port: 5432
   volumePermissions:
     enabled: true
-  resources:
-    limits:
-      cpu: "2"
-      memory: 2048Mi
 
 redis:
   auth:


### PR DESCRIPTION
Due to [this bug](https://medium.com/omio-engineering/cpu-limits-and-aggressive-throttling-in-kubernetes-c5b20bd8a718), Kubernetes was throttling most services. Removing the limits fixed it.  This will make our http responses come ~25% faster.

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] I've read and agree with the [contribution guidelines](https://www.freeboardgames.org/docs/?path=/story/documentation-contributing--page).
