### PR TITLE
Update Schafkopf rules

### DIFF
--- a/web/src/games/schafkopf/components/GameBoard.tsx
+++ b/web/src/games/schafkopf/components/GameBoard.tsx
@@ -104,7 +104,7 @@ export function Board(props: {
     return (
       <Trick
         trick={trick ? trick.cards : []}
-        leaderPos={trick ? +trick.leader.id : 0}
+        leaderPos={trick && trick.leader ? +trick.leader.id : 0}
         winnerPos={trick && trick.winner ? +trick.winner.id : -1}
         currPos={+props.player.id}
         numPlayers={props.players.length}

--- a/web/src/games/schafkopf/components/GameBoard.tsx
+++ b/web/src/games/schafkopf/components/GameBoard.tsx
@@ -130,11 +130,11 @@ export function Board(props: {
     if (!props.selectBid) return;
     const highest_bid = Math.max(...props.players.map((p) => p.bid));
     const allowed_bids = props.players.length == 4 ? [0, 1, 2, 3, 4] : [0, 2, 3, 4];
+    const num_aces = props.player.hand.filter((C) => C.color != CardColor.Herz && C.value == 14).length;
     return allowed_bids.map(util.getBidName).map((name, i) => {
       const text: string = translate(name);
       let selectable = false;
       if (props.selectBid) {
-        let num_aces = props.player.hand.filter((C) => C.color != CardColor.Herz && C.value == 14).length;
         if (allowed_bids[i] == 1 && num_aces == 3) {
           selectable = false;
         } else {
@@ -165,7 +165,11 @@ export function Board(props: {
             if (col == 'Herz') {
               return null;
             }
-            if (props.player.hand.find((C) => C.color == CardColor[col] && C.value == 14)) {
+            const color_in_hand = props.player.hand.filter((C) => C.color == CardColor[col]);
+            if (color_in_hand.some((C) => C.value == 14)) {
+              return null;
+            }
+            if (!color_in_hand.some((C) => C.value != 11 && C.value != 12)) {
               return null;
             }
           }

--- a/web/src/games/schafkopf/game.ts
+++ b/web/src/games/schafkopf/game.ts
@@ -38,7 +38,7 @@ export const SchafkopfGame: Game<IG> = {
       kitty: G.kittyRevealed || playerID == G.takerId ? G.kitty : G.kitty.map(() => dummyCard),
       calledTakerId: null,
       resolvedTricks: G.resolvedTricks.map((T, i) =>
-        i > 0 && i == G.resolvedTricks.length - 1
+        (G.players.length == 4 || i > 0) && i == G.resolvedTricks.length - 1
           ? { ...T, winner: stripSecrets(T.winner), leader: stripSecrets(T.leader) }
           : dummyTrick,
       ),

--- a/web/src/games/schafkopf/game.ts
+++ b/web/src/games/schafkopf/game.ts
@@ -37,6 +37,7 @@ export const SchafkopfGame: Game<IG> = {
       deck: G.deck.map(() => dummyCard),
       kitty: G.kittyRevealed || playerID == G.takerId ? G.kitty : G.kitty.map(() => dummyCard),
       calledTakerId: null,
+      calledMayRun: G.calledTakerId == playerID ? G.calledMayRun : null,
       resolvedTricks: G.resolvedTricks.map((T, i) =>
         (G.players.length == 4 || i > 0) && i == G.resolvedTricks.length - 1
           ? { ...T, winner: stripSecrets(T.winner), leader: stripSecrets(T.leader) }
@@ -59,22 +60,20 @@ export const SchafkopfGame: Game<IG> = {
         const dealerId = G.players.findIndex((P) => P.isDealer);
         const leader = G.players[util.mod(dealerId + 1, ctx.numPlayers)];
         const cmpCards = get_cmpCards(Contract.None, CardColor.Herz);
-        G.deck = getSortedDeck();
-        G.deck = ctx.random.Shuffle(G.deck);
+        Object.assign(G, {
+          ...DefaultIG,
+          players: G.players,
+          deck: ctx.random.Shuffle(getSortedDeck()),
+          trick: { cards: [], leader: leader },
+          roundSummaries: G.roundSummaries,
+        });
         G.players.forEach((P, i) => {
           P.bid = Contract.None;
           P.isTaker = false;
           P.isReady = true;
           P.hand = G.deck.slice(i * handSize, (i + 1) * handSize).sort(cmpCards);
         });
-        G.takerId = '';
-        G.calledCard = null;
-        G.calledTakerId = null;
-        G.trumpSuit = CardColor.Herz;
-        G.contract = Contract.None;
         G.kitty = kittySize == 0 ? [] : G.deck.slice(-kittySize).sort(cmpCards);
-        G.kittyRevealed = false;
-        G.trick = { cards: [], leader: leader };
       },
     },
 
@@ -189,6 +188,9 @@ export const SchafkopfGame: Game<IG> = {
             G.trumpSuit = G.calledCard.color;
           } else {
             G.calledTakerId = getCalledTakerId(G.players, G.calledCard);
+            const calledTaker = util.getPlayerById(G, G.calledTakerId);
+            G.calledMayRun =
+              calledTaker.hand.filter((C) => C.color == G.calledCard.color && !util.isTrump(G, C)).length >= 4 ? 1 : 0;
           }
         }
         const cmpCards = get_cmpCards(G.contract, G.trumpSuit);
@@ -264,6 +266,11 @@ export const SchafkopfGame: Game<IG> = {
 
 export function resolveTrick(G: IG): boolean {
   // returns true if this was the last trick in the game
+  const lead_color = G.trick.cards[0].color;
+  const lead_color_is_called = G.contract == Contract.Ace && G.calledCard.color == lead_color;
+  if (lead_color_is_called && G.calledMayRun == 1) {
+    G.calledMayRun = -1;
+  }
   const winnerId = getTrickWinnerId(G.contract, G.trumpSuit, G.trick);
   const winner = util.getPlayerById(G, winnerId);
   G.trick.winner = winner;

--- a/web/src/games/schafkopf/tests/util.ts
+++ b/web/src/games/schafkopf/tests/util.ts
@@ -119,6 +119,7 @@ export function setup_4players(): IG {
     trick: { cards: [], leader: players[2] },
     resolvedTricks: [],
     calledCard: str2card('GA'),
+    calledMayRun: 0,
     contract: Contract.Ace,
     trumpSuit: CardColor.Herz,
   };

--- a/web/src/games/schafkopf/types.ts
+++ b/web/src/games/schafkopf/types.ts
@@ -45,8 +45,9 @@ export interface IG {
   kittyPrev: ICard[];
   takerId: string;
   calledTakerId?: string;
-  trumpSuit: CardColor;
+  calledMayRun: number;
   calledCard?: ICard;
+  trumpSuit: CardColor;
   contract: Contract;
   trick: ITrick;
   resolvedTricks: ITrick[];
@@ -61,6 +62,8 @@ export const DefaultIG: IG = {
   kittyPrev: [],
   takerId: '',
   calledTakerId: '',
+  calledMayRun: null,
+  calledCard: null,
   trumpSuit: CardColor.Herz,
   contract: Contract.None,
   trick: { cards: [] },

--- a/web/src/games/schafkopf/util/misc.ts
+++ b/web/src/games/schafkopf/util/misc.ts
@@ -1,4 +1,14 @@
-import { IG, IPlayer } from '../types';
+import { Contract, IG, IPlayer, ICard } from '../types';
+
+export function isTrump(G: IG, C: ICard): boolean {
+  if (G.contract == Contract.Wenz) {
+    return C.value == 11;
+  }
+  if (G.contract == Contract.Bettel) {
+    return false;
+  }
+  return C.value == 11 || C.value == 12 || C.color == G.trumpSuit;
+}
 
 export function getBidName(bid: number): string {
   return `bid_${['pass', 'ace', 'bettel', 'wenz', 'solo'][bid]}`;

--- a/web/src/games/schafkopf/util/placement.ts
+++ b/web/src/games/schafkopf/util/placement.ts
@@ -3,29 +3,34 @@ import * as util from './misc';
 
 export function selectableCards(G: IG, playerId: string): boolean[] {
   const player = util.getPlayerById(G, playerId);
+  if (player.hand.length == 1) {
+    return player.hand.map(() => true);
+  }
+  const is_trump = player.hand.map((C) => util.isTrump(G, C));
+  const calledCard: ICard = G.contract == Contract.Ace ? G.calledCard : { color: null, value: 0 };
+  const is_called_color = player.hand.map((C, i) => C.color == calledCard.color && !is_trump[i]);
+  const has_called_card =
+    G.contract == Contract.Ace && player.hand.some((C, i) => is_called_color[i] && C.value == calledCard.value);
   if (G.trick.cards.length == 0) {
-    return player.hand.map(() => true);
+    return player.hand.map((C, i) => {
+      if (!has_called_card || G.calledMayRun != 0) {
+        return true;
+      }
+      return !is_called_color[i] || C.value == calledCard.value;
+    });
   }
-  const is_trump = player.hand.map((C) => isTrump(G, C));
-  if (isTrump(G, G.trick.cards[0])) {
-    return is_trump.some((v) => v) ? is_trump : player.hand.map(() => true);
-  }
+  const lead_is_trump = util.isTrump(G, G.trick.cards[0]);
   const lead_color = G.trick.cards[0].color;
-  const can_follow_suit = player.hand.filter((C, i) => C.color == lead_color && !is_trump[i]).length > 0;
-  if (!can_follow_suit) {
-    return player.hand.map(() => true);
-  }
+  const is_lead_color = lead_is_trump ? is_trump : player.hand.map((C, i) => C.color == lead_color && !is_trump[i]);
+  const can_follow_suit = is_lead_color.some((v) => v);
+  const called_has_run = G.calledMayRun < 0;
   return player.hand.map((C, i) => {
-    return C.color == lead_color && !is_trump[i];
+    if (!can_follow_suit) {
+      return !has_called_card || called_has_run || !is_called_color[i] || C.value != calledCard.value;
+    }
+    if (!has_called_card || lead_is_trump || lead_color != calledCard.color) {
+      return is_lead_color[i];
+    }
+    return called_has_run || C.value == calledCard.value;
   });
-}
-
-export function isTrump(G: IG, C: ICard): boolean {
-  if (G.contract == Contract.Wenz) {
-    return C.value == 11;
-  }
-  if (G.contract == Contract.Bettel) {
-    return false;
-  }
-  return C.value == 11 || C.value == 12 || C.color == G.trumpSuit;
 }


### PR DESCRIPTION
This fixes a little UI problem and adds a "called player runs away" rule to the Schafkopf game for 4 players: There are no "official" rules for this game, but typically, there are restrictions in which situations the called player is allowed to play the called suit (i.e., "run away"), especially the Ace.

There are more rule variants for Schafkopf, especially for the round scoring, but I felt like this one is the most important missing from the current implementation. Furthermore, the UI problem made the game unplayable in some situations (with a React error message on the screen).

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] I've read and agree with the [contribution guidelines](https://www.freeboardgames.org/docs/?path=/story/documentation-contributing--page).
