### PR TITLE
Replace mkdir and cp in copy.ts with native Node calls.

### DIFF
--- a/web/server/config/i18n/sync/copy.ts
+++ b/web/server/config/i18n/sync/copy.ts
@@ -1,10 +1,14 @@
-import { execSync } from 'child_process';
 import { regexp } from './constants';
+import { copyFileSync, existsSync, mkdirSync } from 'fs';
 
+/* eslint-disable no-console */
 export function copy(source: string, target: string) {
   const [, game, locale] = source.match(regexp) || [];
   const parent = `${target}/${locale}/games`;
+  if (!existsSync(parent)) {
+    mkdirSync(parent);
+  }
   const file = `${parent}/${game}.json`;
-  execSync(`mkdir -p ${parent} && cp "${source}" "${file}"`, { stdio: 'inherit' });
+  copyFileSync(source, file);
   console.log(`${file} > OK`);
 }


### PR DESCRIPTION
`mkdir` and `cp` do not work on Windows as-is because they take different formats there. For instance, `mkdir` on Windows uses `-Force` instead of `-p`. Using Node calls should make the script OS-agnostic.

#### Checklist

* [X] Use a separate branch in your local repo (not `master`).
* [X] I've read and agree with the [contribution guidelines](https://www.freeboardgames.org/docs/?path=/story/documentation-contributing--page).
