### PR TITLE
Make Scoreboard component extensible

### DIFF
--- a/web/src/gamesShared/components/scores/Scoreboard.stories.tsx
+++ b/web/src/gamesShared/components/scores/Scoreboard.stories.tsx
@@ -10,6 +10,14 @@ const scores = [
   { playerID: '2', score: 300 },
 ];
 
+const scoresExtended = [
+  { playerID: '0', score: 100, extraData: [1, 5] },
+  { playerID: '1', score: 200, extraData: [2, 10] },
+  { playerID: '2', score: 300, extraData: [3, 15] },
+];
+
+const extraColumns = ['Foo', 'Bar'];
+
 const players = [
   { playerID: 0, name: 'Bob' },
   { playerID: 1, name: 'Alice' },
@@ -17,3 +25,6 @@ const players = [
 ];
 
 export const example = () => <Scoreboard scoreboard={scores} players={players} playerID={'1'} />;
+export const extensibleExample = () => (
+  <Scoreboard scoreboard={scoresExtended} players={players} playerID={'1'} extraColumns={extraColumns} />
+);

--- a/web/src/gamesShared/components/scores/Scoreboard.tsx
+++ b/web/src/gamesShared/components/scores/Scoreboard.tsx
@@ -11,6 +11,7 @@ import React from 'react';
 export interface IScore {
   playerID: string;
   score: number;
+  extraData?: any[];
 }
 
 interface IScoreboardProps {
@@ -18,6 +19,7 @@ interface IScoreboardProps {
   players: IPlayerInRoom[];
   playerID: string;
   scoreName?: string;
+  extraColumns?: string[];
 }
 
 export function Scoreboard(props: IScoreboardProps) {
@@ -30,6 +32,7 @@ export function Scoreboard(props: IScoreboardProps) {
           <TableRow>
             <TableCell>{t('rank')}</TableCell>
             <TableCell>{t('player')}</TableCell>
+            {props.extraColumns && props.extraColumns.map((text) => <TableCell key={text}>{text}</TableCell>)}
             <TableCell>{props.scoreName || t('score')}</TableCell>
           </TableRow>
         </TableHead>
@@ -46,6 +49,8 @@ export function Scoreboard(props: IScoreboardProps) {
               <TableRow key={score.playerID} style={style}>
                 <TableCell>#{i + 1}</TableCell>
                 <TableCell>{name}</TableCell>
+                {score.extraData &&
+                  score.extraData.map((val) => <TableCell key={props.extraColumns[i]}>{val}</TableCell>)}
                 <TableCell>{score.score}</TableCell>
               </TableRow>
             );


### PR DESCRIPTION
#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] I've read and agree with the [contribution guidelines](https://www.freeboardgames.org/docs/?path=/story/documentation-contributing--page).

This allows the `Scoreboard` component to be extended with as many additional columns as necessary per game. I've also implemented a visible example with storyboard. Hopefully, it shouldn't be too hard to figure out what this is supposed to do based on the example I provided.

Feel free to merge if everything looks good as it is, but I do have two points I'd like to raise:
- Right now, all the extra components are listed between the player name and the score. Should this be moved after the score instead?
- There's currently no check to ensure that `extraData` and `extraColumns` are the same length. I admit that I don't know how to make react throw an error properly here, but I'm not sure how necessary that check is, since the columns would obviously look misaligned anyways if there's a length mismatch.