### PR TITLE
Picnic Go: make move functions in board async

### DIFF
--- a/web/src/games/picnicGo/board.tsx
+++ b/web/src/games/picnicGo/board.tsx
@@ -29,21 +29,21 @@ export function Board(props: IBoardProps) {
     }
   }
 
-  const _selectCard = (id: number) => {
+  const _selectCard = async (id: number) => {
     if (!_canPlay() || props.ctx.phase !== 'play') {
       return;
     }
     props.moves.selectCard(id);
   };
 
-  const _useFork = () => {
+  const _useFork = async () => {
     if (!_canPlay() || props.ctx.phase !== 'play') {
       return;
     }
     props.moves.useFork();
   };
 
-  const _confirmScore = () => {
+  const _confirmScore = async () => {
     if (!_canPlay() || props.ctx.phase !== 'score') {
       return;
     }


### PR DESCRIPTION
#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] I've read and agree with the [contribution guidelines](https://www.freeboardgames.org/docs/?path=/story/documentation-contributing--page).

After some playtesting with my friends, it seems there's a problem that occurs when multiple players make a move at nearly the same time, where one of the moves will fall through, and the player would need to click again for the move to properly register. After studying Take Six's code (which is another game with simultaneous turns), I've decided to follow its example and try making the move functions asynchorous to see if this would fix the problem.

This is not a tested patch, as I unfortunately don't have any way to test out making moves on multiple players at the same time - however, at the very least, this does not break any existing functionality, so in the worst case scenario, this commit does nothing. In the best case, though, this should fix the strange "lag" issue that's been happening.