### PR TITLE
Checkers: A lot of general improvements, new customization settings

### DIFF
--- a/web/src/games/checkers/board.test.tsx
+++ b/web/src/games/checkers/board.test.tsx
@@ -5,6 +5,8 @@ import { Client } from 'boardgame.io/client';
 import { Client as ReactClient } from 'boardgame.io/react';
 import { CheckersGame } from './game';
 
+import blue from '@material-ui/core/colors/blue';
+
 import { Board } from './board';
 import { GameMode } from 'gamesShared/definitions/mode';
 
@@ -71,7 +73,7 @@ test('highlighting the only valid move', async () => {
   comp.setProps({ playerID: '1' });
   comp.update();
 
-  expect(comp.find(Board).state('selected')).toEqual({ x: 0, y: 3 });
+  expect(comp.find('rect').at(getPosition(0, 3)).prop('style').fill).toEqual(blue[700]);
   comp.unmount();
 });
 

--- a/web/src/games/checkers/board.test.tsx
+++ b/web/src/games/checkers/board.test.tsx
@@ -125,6 +125,30 @@ test('gameover - lost', () => {
   expect(comp.html()).toContain('black');
 });
 
+test('gameover - draw', () => {
+  const client = Client({
+    game: CheckersGame,
+  });
+  const state0 = client.store.getState();
+  const state1 = {
+    ...state0,
+    ctx: { ...state0.ctx, gameover: { winner: 'draw' } },
+  };
+  const comp = Enzyme.mount(
+    <Board
+      G={state1.G}
+      ctx={state1.ctx}
+      moves={client.moves}
+      playerID={'0'}
+      gameArgs={{
+        gameCode: 'checkers',
+        mode: GameMode.LocalFriend,
+      }}
+    />,
+  );
+  expect(comp.html()).toContain('draw');
+});
+
 test('gameover - won online', () => {
   const client = Client({
     game: CheckersGame,

--- a/web/src/games/checkers/board.test.tsx
+++ b/web/src/games/checkers/board.test.tsx
@@ -6,6 +6,7 @@ import { Client as ReactClient } from 'boardgame.io/react';
 import { CheckersGame } from './game';
 
 import blue from '@material-ui/core/colors/blue';
+import cyan from '@material-ui/core/colors/cyan';
 
 import { Board } from './board';
 import { GameMode } from 'gamesShared/definitions/mode';
@@ -75,6 +76,31 @@ test('highlighting the only valid move', async () => {
 
   expect(comp.find('rect').at(getPosition(0, 3)).prop('style').fill).toEqual(blue[700]);
   comp.unmount();
+});
+
+test('highlighting selectable pieces with forced capture', async () => {
+  const App = ReactClient({
+    game: CheckersGame,
+    debug: false,
+    board: BoardTest,
+  });
+  const comp = Enzyme.mount(<App playerID={'0'} />);
+
+  await comp.find('rect').at(getPosition(4, 5)).simulate('click');
+  await comp.find('rect').at(getPosition(3, 4)).simulate('click');
+  comp.setProps({ playerID: '1' });
+  comp.update();
+  await comp.find('rect').at(getPosition(1, 2)).simulate('click');
+  await comp.find('rect').at(getPosition(0, 3)).simulate('click');
+  comp.setProps({ playerID: '0' });
+  comp.update();
+  await comp.find('rect').at(getPosition(3, 4)).simulate('click');
+  await comp.find('rect').at(getPosition(4, 3)).simulate('click');
+  comp.setProps({ playerID: '1' });
+  comp.update();
+
+  expect(comp.find('rect').at(getPosition(3, 2)).prop('style').fill).toEqual(cyan[500]);
+  expect(comp.find('rect').at(getPosition(5, 2)).prop('style').fill).toEqual(cyan[500]);
 });
 
 test('gameover - won', () => {

--- a/web/src/games/checkers/board.tsx
+++ b/web/src/games/checkers/board.tsx
@@ -173,12 +173,16 @@ export function Board(props: IBoardProps) {
       if (isFirstPersonView(props.gameArgs, props.playerID)) {
         if (winner === props.playerID) {
           return 'you won';
+        } else if (winner === 'draw') {
+          return 'draw';
         } else {
           return 'you lost';
         }
       } else {
         if (winner === '0') {
           return 'white won';
+        } else if (winner === 'draw') {
+          return 'draw';
         } else {
           return 'black won';
         }

--- a/web/src/games/checkers/board.tsx
+++ b/web/src/games/checkers/board.tsx
@@ -30,82 +30,66 @@ interface IBoardProps {
   gameArgs?: IGameArgs;
 }
 
-interface IBoardState {
-  selected: ICartesianCoords;
-  validMoves: IMove[];
-}
-
 function roundCoords(coords: ICartesianCoords) {
   return { x: Math.round(coords.x), y: Math.round(coords.y) };
 }
 
-export class Board extends React.Component<IBoardProps, IBoardState> {
-  state: IBoardState = {
-    selected: null,
-    validMoves: getValidMoves(this.props.G, this.props.ctx.currentPlayer),
-  };
+export function Board(props: IBoardProps) {
+  const [selected, setSelected] = React.useState(null);
+  const [validMoves, setValidMoves] = React.useState(getValidMoves(props.G, props.ctx.currentPlayer));
 
-  isInverted() {
-    return (isAIGame(this.props.gameArgs) || isOnlineGame(this.props.gameArgs)) && this.props.playerID === '1';
+  function isInverted() {
+    return (isAIGame(props.gameArgs) || isOnlineGame(props.gameArgs)) && props.playerID === '1';
   }
 
-  _isSelectable = (coords: ICartesianCoords) => {
-    if (isOnlineGame(this.props.gameArgs) && this.props.playerID !== this.props.ctx.currentPlayer) {
+  const _isSelectable = (coords: ICartesianCoords) => {
+    if (isOnlineGame(props.gameArgs) && props.playerID !== props.ctx.currentPlayer) {
       return false;
     }
 
-    return this.state.validMoves.some((move) => equals(move.from, coords));
+    return validMoves.some((move) => equals(move.from, coords));
   };
 
-  _onClick = (coords: IAlgebraicCoords) => {
+  const _onClick = (coords: IAlgebraicCoords) => {
     const position = algebraicToCartesian(coords.square);
-    if (this.state.selected === null && this._isSelectable(position)) {
-      this.setState({
-        ...this.state,
-        selected: position,
-      });
+    if (selected === null && _isSelectable(position)) {
+      setSelected(position);
     } else {
-      this._move(position);
+      _move(position);
     }
   };
 
-  _shouldDrag = (coords: ICartesianCoords) => {
-    return this._isSelectable(applyInvertion(coords, this.isInverted()));
+  const _shouldDrag = (coords: ICartesianCoords) => {
+    return _isSelectable(applyInvertion(coords, isInverted()));
   };
 
-  _onDrag = (coords: IOnDragData) => {
+  const _onDrag = (coords: IOnDragData) => {
     const x = coords.x;
     const y = coords.y;
     const originalX = coords.originalX;
     const originalY = coords.originalY;
     if (Math.sqrt((x - originalX) ** 2 + (y - originalY) ** 2) > 0.2) {
-      this.setState({
-        ...this.state,
-        selected: applyInvertion({ x: originalX, y: originalY }, this.isInverted()),
-      });
+      setSelected(applyInvertion({ x: originalX, y: originalY }, isInverted()));
     } else {
-      this.setState({
-        ...this.state,
-        selected: null,
-      });
+      setSelected(null);
     }
   };
 
-  _onDrop = async (coords: ICartesianCoords) => {
-    if (this.state.selected) {
-      this._move(applyInvertion(roundCoords(coords), this.isInverted()));
+  const _onDrop = async (coords: ICartesianCoords) => {
+    if (selected) {
+      _move(applyInvertion(roundCoords(coords), isInverted()));
     }
   };
 
-  _move = async (coords: ICartesianCoords) => {
-    if (this.state.selected === null || coords === null) {
+  const _move = async (coords: ICartesianCoords) => {
+    if (selected === null || coords === null) {
       return;
     }
 
-    await this.props.moves.move(this.state.selected, coords);
+    await props.moves.move(selected, coords);
   };
 
-  private _getPreselectedMove(validMoves: IMove[]): ICartesianCoords {
+  function _getPreselectedMove(validMoves: IMove[]): ICartesianCoords {
     if (validMoves.length === 1) {
       const from = validMoves[0].from;
       return { x: from.x, y: from.y };
@@ -113,13 +97,23 @@ export class Board extends React.Component<IBoardProps, IBoardState> {
     return null;
   }
 
-  _getHighlightedSquares() {
+  React.useEffect(() => {
+    const newValidMoves =
+      props.G.jumping === null
+        ? getValidMoves(props.G, props.ctx.currentPlayer)
+        : getValidMoves(props.G, props.ctx.currentPlayer, props.G.jumping);
+
+    setValidMoves(newValidMoves);
+    setSelected(_getPreselectedMove(newValidMoves));
+  }, [props.ctx.turn]);
+
+  function _getHighlightedSquares() {
     const result = {} as IColorMap;
 
-    if (this.state.selected !== null) {
-      result[cartesianToAlgebraic(this.state.selected.x, this.state.selected.y, false)] = blue[700];
-      this.state.validMoves
-        .filter((move) => equals(move.from, this.state.selected))
+    if (selected !== null) {
+      result[cartesianToAlgebraic(selected.x, selected.y, false)] = blue[700];
+      validMoves
+        .filter((move) => equals(move.from, selected))
         .forEach((move) => {
           result[cartesianToAlgebraic(move.to.x, move.to.y, false)] = blue[500];
         });
@@ -128,8 +122,8 @@ export class Board extends React.Component<IBoardProps, IBoardState> {
     return result;
   }
 
-  getPieces = () => {
-    return this.props.G.board
+  const getPieces = () => {
+    return props.G.board
       .map((piece, index) => ({ data: piece, index }))
       .filter((piece) => piece.data !== null)
       .map((piece) => {
@@ -139,9 +133,9 @@ export class Board extends React.Component<IBoardProps, IBoardState> {
             x={x}
             y={y}
             draggable={true}
-            shouldDrag={this._shouldDrag}
-            onDrop={this._onDrop}
-            onDrag={this._onDrag}
+            shouldDrag={_shouldDrag}
+            onDrop={_onDrop}
+            onDrag={_onDrag}
             animate={true}
             key={piece.data.id}
           >
@@ -156,15 +150,15 @@ export class Board extends React.Component<IBoardProps, IBoardState> {
       });
   };
 
-  _getStatus() {
-    if (isFirstPersonView(this.props.gameArgs, this.props.playerID)) {
-      if (this.props.ctx.currentPlayer === this.props.playerID) {
+  function _getStatus() {
+    if (isFirstPersonView(props.gameArgs, props.playerID)) {
+      if (props.ctx.currentPlayer === props.playerID) {
         return 'Move piece';
       } else {
         return 'Waiting for opponent...';
       }
     } else {
-      switch (this.props.ctx.currentPlayer) {
+      switch (props.ctx.currentPlayer) {
         case '0':
           return "White's turn";
         case '1':
@@ -173,11 +167,11 @@ export class Board extends React.Component<IBoardProps, IBoardState> {
     }
   }
 
-  _getGameOver() {
-    const winner = this.props.ctx.gameover.winner;
+  function _getGameOver() {
+    const winner = props.ctx.gameover.winner;
     if (winner) {
-      if (isFirstPersonView(this.props.gameArgs, this.props.playerID)) {
-        if (winner === this.props.playerID) {
+      if (isFirstPersonView(props.gameArgs, props.playerID)) {
+        if (winner === props.playerID) {
           return 'you won';
         } else {
           return 'you lost';
@@ -192,39 +186,22 @@ export class Board extends React.Component<IBoardProps, IBoardState> {
     }
   }
 
-  componentDidUpdate(prevProps: IBoardProps) {
-    if (prevProps.ctx.turn !== this.props.ctx.turn) {
-      const validMoves =
-        this.props.G.jumping === null
-          ? getValidMoves(this.props.G, this.props.ctx.currentPlayer)
-          : getValidMoves(this.props.G, this.props.ctx.currentPlayer, this.props.G.jumping);
-
-      this.setState({
-        ...this.state,
-        validMoves,
-        selected: this._getPreselectedMove(validMoves),
-      });
-    }
-  }
-
-  render() {
-    if (this.props.ctx.gameover) {
-      return <GameLayout gameOver={this._getGameOver()} gameArgs={this.props.gameArgs} />;
+  function render() {
+    if (props.ctx.gameover) {
+      return <GameLayout gameOver={_getGameOver()} gameArgs={props.gameArgs} />;
     }
 
     return (
-      <GameLayout gameArgs={this.props.gameArgs}>
+      <GameLayout gameArgs={props.gameArgs}>
         <Typography variant="h5" style={{ textAlign: 'center', color: 'white', marginBottom: '16px' }}>
-          {this._getStatus()}
+          {_getStatus()}
         </Typography>
-        <Checkerboard
-          onClick={this._onClick}
-          invert={this.isInverted()}
-          highlightedSquares={this._getHighlightedSquares()}
-        >
-          {this.getPieces()}
+        <Checkerboard onClick={_onClick} invert={isInverted()} highlightedSquares={_getHighlightedSquares()}>
+          {getPieces()}
         </Checkerboard>
       </GameLayout>
     );
   }
+
+  return render();
 }

--- a/web/src/games/checkers/board.tsx
+++ b/web/src/games/checkers/board.tsx
@@ -20,6 +20,7 @@ import grey from '@material-ui/core/colors/grey';
 import blue from '@material-ui/core/colors/blue';
 import { isOnlineGame, isAIGame } from '../../gamesShared/helpers/gameMode';
 import { isFirstPersonView } from 'gamesShared/helpers/GameUtil';
+import { useCurrentGameTranslation } from 'infra/i18n';
 
 interface IBoardProps {
   G: IG;
@@ -35,6 +36,8 @@ function roundCoords(coords: ICartesianCoords) {
 }
 
 export function Board(props: IBoardProps) {
+  const { translate } = useCurrentGameTranslation();
+
   const [selected, setSelected] = React.useState(null);
   const [validMoves, setValidMoves] = React.useState(getValidMoves(props.G, props.ctx.currentPlayer));
 
@@ -153,16 +156,16 @@ export function Board(props: IBoardProps) {
   function _getStatus() {
     if (isFirstPersonView(props.gameArgs, props.playerID)) {
       if (props.ctx.currentPlayer === props.playerID) {
-        return 'Move piece';
+        return translate('move_piece');
       } else {
-        return 'Waiting for opponent...';
+        return translate('waiting_for_opponent');
       }
     } else {
       switch (props.ctx.currentPlayer) {
         case '0':
-          return "White's turn";
+          return translate('white_turn');
         case '1':
-          return "Black's turn";
+          return translate('black_turn');
       }
     }
   }
@@ -172,19 +175,19 @@ export function Board(props: IBoardProps) {
     if (winner) {
       if (isFirstPersonView(props.gameArgs, props.playerID)) {
         if (winner === props.playerID) {
-          return 'you won';
+          return translate('game_over.you_won');
         } else if (winner === 'draw') {
-          return 'draw';
+          return translate('game_over.draw');
         } else {
-          return 'you lost';
+          return translate('game_over.you_lost');
         }
       } else {
         if (winner === '0') {
-          return 'white won';
+          return translate('game_over.white_won');
         } else if (winner === 'draw') {
-          return 'draw';
+          return translate('game_over.draw');
         } else {
-          return 'black won';
+          return translate('game_over.black_won');
         }
       }
     }

--- a/web/src/games/checkers/board.tsx
+++ b/web/src/games/checkers/board.tsx
@@ -18,6 +18,7 @@ import { Token } from 'deprecated-bgio-ui';
 import Typography from '@material-ui/core/Typography';
 import grey from '@material-ui/core/colors/grey';
 import blue from '@material-ui/core/colors/blue';
+import cyan from '@material-ui/core/colors/cyan';
 import { isOnlineGame, isAIGame } from '../../gamesShared/helpers/gameMode';
 import { isFirstPersonView } from 'gamesShared/helpers/GameUtil';
 import { useCurrentGameTranslation } from 'infra/i18n';
@@ -120,6 +121,10 @@ export function Board(props: IBoardProps) {
         .forEach((move) => {
           result[cartesianToAlgebraic(move.to.x, move.to.y, false)] = blue[500];
         });
+    } else if (props.G.config.forcedCapture && validMoves.some((move) => move.jumped)) {
+      validMoves.forEach((move) => {
+        result[cartesianToAlgebraic(move.from.x, move.from.y, false)] = cyan[500];
+      });
     }
 
     return result;

--- a/web/src/games/checkers/customization.tsx
+++ b/web/src/games/checkers/customization.tsx
@@ -15,6 +15,7 @@ export interface FullCustomizationState {
   forcedCapture: boolean;
   flyingKings: boolean;
   stopJumpOnKing: boolean;
+  nMoveRule: number;
 }
 
 export const DEFAULT_FULL_CUSTOMIZATION: FullCustomizationState = {
@@ -22,6 +23,7 @@ export const DEFAULT_FULL_CUSTOMIZATION: FullCustomizationState = {
   forcedCapture: true,
   flyingKings: false,
   stopJumpOnKing: true,
+  nMoveRule: 40,
 };
 
 const changePiecesPerPlayer = (onChange: (state?: FullCustomizationState) => void, state: FullCustomizationState) => (
@@ -65,6 +67,17 @@ const changeStopJumpOnKing = (
   onChange(newState);
 };
 
+const changeNMoveRule = (onChange: (state?: FullCustomizationState) => void, state: FullCustomizationState) => (
+  event: React.ChangeEvent<{ value: number }>,
+) => {
+  const index = event.target.value;
+  const newState: FullCustomizationState = {
+    ...state,
+    nMoveRule: index,
+  };
+  onChange(newState);
+};
+
 const FullCustomization = ({ currentValue, onChange }: GameCustomizationProps) => {
   const state = (currentValue as FullCustomizationState) || DEFAULT_FULL_CUSTOMIZATION;
   const style = {
@@ -89,6 +102,13 @@ const FullCustomization = ({ currentValue, onChange }: GameCustomizationProps) =
       <Switch checked={state.flyingKings} onChange={changeFlyingKings(onChange, state)} color="primary" />
       <Typography align="right">Stop Jumping If Piece Kinged</Typography>
       <Switch checked={state.stopJumpOnKing} onChange={changeStopJumpOnKing(onChange, state)} color="primary" />
+      <Typography align="right">n-move Rule</Typography>
+      <Select value={state.nMoveRule} onChange={changeNMoveRule(onChange, state)} style={{ width: '100%' }}>
+        <MenuItem value={-1}>Off</MenuItem>
+        <MenuItem value={15}>15</MenuItem>
+        <MenuItem value={30}>30</MenuItem>
+        <MenuItem value={40}>40</MenuItem>
+      </Select>
     </div>
   );
 };

--- a/web/src/games/checkers/customization.tsx
+++ b/web/src/games/checkers/customization.tsx
@@ -6,13 +6,13 @@ import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
 import { useCurrentGameTranslation } from 'infra/i18n';
 
-export enum piecesPerPlayer {
+export enum PiecesPerPlayer {
   TWELVE,
   EIGHT,
 }
 
 export interface FullCustomizationState {
-  piecesPerPlayer: piecesPerPlayer;
+  piecesPerPlayer: PiecesPerPlayer;
   forcedCapture: boolean;
   flyingKings: boolean;
   stopJumpOnKing: boolean;
@@ -20,7 +20,7 @@ export interface FullCustomizationState {
 }
 
 export const DEFAULT_FULL_CUSTOMIZATION: FullCustomizationState = {
-  piecesPerPlayer: piecesPerPlayer.TWELVE,
+  piecesPerPlayer: PiecesPerPlayer.TWELVE,
   forcedCapture: true,
   flyingKings: false,
   stopJumpOnKing: true,
@@ -28,7 +28,7 @@ export const DEFAULT_FULL_CUSTOMIZATION: FullCustomizationState = {
 };
 
 const changePiecesPerPlayer = (onChange: (state?: FullCustomizationState) => void, state: FullCustomizationState) => (
-  event: React.ChangeEvent<{ value: piecesPerPlayer }>,
+  event: React.ChangeEvent<{ value: PiecesPerPlayer }>,
 ) => {
   const index = event.target.value;
   const newState: FullCustomizationState = {
@@ -95,8 +95,8 @@ const FullCustomization = ({ currentValue, onChange }: GameCustomizationProps) =
     <div style={style}>
       <Typography align="right">{translate('customization.pieces_per_player')}</Typography>
       <Select value={state.piecesPerPlayer} onChange={changePiecesPerPlayer(onChange, state)} style={{ width: '100%' }}>
-        <MenuItem value={piecesPerPlayer.TWELVE}>12</MenuItem>
-        <MenuItem value={piecesPerPlayer.EIGHT}>8</MenuItem>
+        <MenuItem value={PiecesPerPlayer.TWELVE}>12</MenuItem>
+        <MenuItem value={PiecesPerPlayer.EIGHT}>8</MenuItem>
       </Select>
       <Typography align="right">{translate('customization.forced_capture')}</Typography>
       <Switch checked={state.forcedCapture} onChange={changeForcedCapture(onChange, state)} color="primary" />

--- a/web/src/games/checkers/customization.tsx
+++ b/web/src/games/checkers/customization.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { GameCustomization, GameCustomizationProps } from 'gamesShared/definitions/customization';
+import Typography from '@material-ui/core/Typography';
+import Switch from '@material-ui/core/Switch';
+
+export interface FullCustomizationState {
+  flyingKings: boolean;
+}
+
+export const DEFAULT_FULL_CUSTOMIZATION: FullCustomizationState = {
+  flyingKings: false,
+};
+
+const changeFlyingKings = (onChange: (state?: FullCustomizationState) => void, state: FullCustomizationState) => () => {
+  const newState: FullCustomizationState = {
+    ...state,
+    flyingKings: !state.flyingKings,
+  };
+  onChange(newState);
+};
+
+const FullCustomization = ({ currentValue, onChange }: GameCustomizationProps) => {
+  const state = (currentValue as FullCustomizationState) || DEFAULT_FULL_CUSTOMIZATION;
+  const style = {
+    padding: '16px',
+    display: 'grid',
+    gridTemplateColumns: 'max-content max-content',
+    gridAutoRows: '2em',
+    columnGap: '16px',
+    alignItems: 'center',
+  };
+
+  return (
+    <div style={style}>
+      <Typography align="right">Flying Kings</Typography>
+      <Switch checked={state.flyingKings} onChange={changeFlyingKings(onChange, state)} color="primary" />
+    </div>
+  );
+};
+
+const customization: GameCustomization = {
+  FullCustomization,
+};
+
+export default customization;

--- a/web/src/games/checkers/customization.tsx
+++ b/web/src/games/checkers/customization.tsx
@@ -2,12 +2,21 @@ import * as React from 'react';
 import { GameCustomization, GameCustomizationProps } from 'gamesShared/definitions/customization';
 import Typography from '@material-ui/core/Typography';
 import Switch from '@material-ui/core/Switch';
+import Select from '@material-ui/core/Select';
+import MenuItem from '@material-ui/core/MenuItem';
+
+export enum piecesPerPlayer {
+  TWELVE,
+  EIGHT,
+}
 
 export interface FullCustomizationState {
+  piecesPerPlayer: piecesPerPlayer;
   flyingKings: boolean;
 }
 
 export const DEFAULT_FULL_CUSTOMIZATION: FullCustomizationState = {
+  piecesPerPlayer: piecesPerPlayer.TWELVE,
   flyingKings: false,
 };
 
@@ -19,19 +28,35 @@ const changeFlyingKings = (onChange: (state?: FullCustomizationState) => void, s
   onChange(newState);
 };
 
+const changePiecesPerPlayer = (onChange: (state?: FullCustomizationState) => void, state: FullCustomizationState) => (
+  event: React.ChangeEvent<{ value: piecesPerPlayer }>,
+) => {
+  const index = event.target.value;
+  const newState: FullCustomizationState = {
+    ...state,
+    piecesPerPlayer: index,
+  };
+  onChange(newState);
+};
+
 const FullCustomization = ({ currentValue, onChange }: GameCustomizationProps) => {
   const state = (currentValue as FullCustomizationState) || DEFAULT_FULL_CUSTOMIZATION;
   const style = {
     padding: '16px',
     display: 'grid',
     gridTemplateColumns: 'max-content max-content',
-    gridAutoRows: '2em',
+    gridAutoRows: '36px',
     columnGap: '16px',
     alignItems: 'center',
   };
 
   return (
     <div style={style}>
+      <Typography align="right">Pieces per Player</Typography>
+      <Select value={state.piecesPerPlayer} onChange={changePiecesPerPlayer(onChange, state)} style={{ width: '100%' }}>
+        <MenuItem value={piecesPerPlayer.TWELVE}>12</MenuItem>
+        <MenuItem value={piecesPerPlayer.EIGHT}>8</MenuItem>
+      </Select>
       <Typography align="right">Flying Kings</Typography>
       <Switch checked={state.flyingKings} onChange={changeFlyingKings(onChange, state)} color="primary" />
     </div>

--- a/web/src/games/checkers/customization.tsx
+++ b/web/src/games/checkers/customization.tsx
@@ -4,6 +4,7 @@ import Typography from '@material-ui/core/Typography';
 import Switch from '@material-ui/core/Switch';
 import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
+import { useCurrentGameTranslation } from 'infra/i18n';
 
 export enum piecesPerPlayer {
   TWELVE,
@@ -79,6 +80,7 @@ const changeNMoveRule = (onChange: (state?: FullCustomizationState) => void, sta
 };
 
 const FullCustomization = ({ currentValue, onChange }: GameCustomizationProps) => {
+  const { translate } = useCurrentGameTranslation();
   const state = (currentValue as FullCustomizationState) || DEFAULT_FULL_CUSTOMIZATION;
   const style = {
     padding: '16px',
@@ -91,20 +93,20 @@ const FullCustomization = ({ currentValue, onChange }: GameCustomizationProps) =
 
   return (
     <div style={style}>
-      <Typography align="right">Pieces Per Player</Typography>
+      <Typography align="right">{translate('customization.pieces_per_player')}</Typography>
       <Select value={state.piecesPerPlayer} onChange={changePiecesPerPlayer(onChange, state)} style={{ width: '100%' }}>
         <MenuItem value={piecesPerPlayer.TWELVE}>12</MenuItem>
         <MenuItem value={piecesPerPlayer.EIGHT}>8</MenuItem>
       </Select>
-      <Typography align="right">Forced Capture</Typography>
+      <Typography align="right">{translate('customization.forced_capture')}</Typography>
       <Switch checked={state.forcedCapture} onChange={changeForcedCapture(onChange, state)} color="primary" />
-      <Typography align="right">Flying Kings</Typography>
+      <Typography align="right">{translate('customization.flying_kings')}</Typography>
       <Switch checked={state.flyingKings} onChange={changeFlyingKings(onChange, state)} color="primary" />
-      <Typography align="right">Stop Jumping If Piece Kinged</Typography>
+      <Typography align="right">{translate('customization.stop_jump_on_king')}</Typography>
       <Switch checked={state.stopJumpOnKing} onChange={changeStopJumpOnKing(onChange, state)} color="primary" />
-      <Typography align="right">n-move Rule</Typography>
+      <Typography align="right">{translate('customization.n_move_rule.label')}</Typography>
       <Select value={state.nMoveRule} onChange={changeNMoveRule(onChange, state)} style={{ width: '100%' }}>
-        <MenuItem value={-1}>Off</MenuItem>
+        <MenuItem value={-1}>{translate('customization.n_move_rule.off')}</MenuItem>
         <MenuItem value={15}>15</MenuItem>
         <MenuItem value={30}>30</MenuItem>
         <MenuItem value={40}>40</MenuItem>

--- a/web/src/games/checkers/customization.tsx
+++ b/web/src/games/checkers/customization.tsx
@@ -12,12 +12,14 @@ export enum piecesPerPlayer {
 
 export interface FullCustomizationState {
   piecesPerPlayer: piecesPerPlayer;
+  forcedCapture: boolean;
   flyingKings: boolean;
   stopJumpOnKing: boolean;
 }
 
 export const DEFAULT_FULL_CUSTOMIZATION: FullCustomizationState = {
   piecesPerPlayer: piecesPerPlayer.TWELVE,
+  forcedCapture: true,
   flyingKings: false,
   stopJumpOnKing: true,
 };
@@ -29,6 +31,17 @@ const changePiecesPerPlayer = (onChange: (state?: FullCustomizationState) => voi
   const newState: FullCustomizationState = {
     ...state,
     piecesPerPlayer: index,
+  };
+  onChange(newState);
+};
+
+const changeForcedCapture = (
+  onChange: (state?: FullCustomizationState) => void,
+  state: FullCustomizationState,
+) => () => {
+  const newState: FullCustomizationState = {
+    ...state,
+    forcedCapture: !state.forcedCapture,
   };
   onChange(newState);
 };
@@ -70,6 +83,8 @@ const FullCustomization = ({ currentValue, onChange }: GameCustomizationProps) =
         <MenuItem value={piecesPerPlayer.TWELVE}>12</MenuItem>
         <MenuItem value={piecesPerPlayer.EIGHT}>8</MenuItem>
       </Select>
+      <Typography align="right">Forced Capture</Typography>
+      <Switch checked={state.forcedCapture} onChange={changeForcedCapture(onChange, state)} color="primary" />
       <Typography align="right">Flying Kings</Typography>
       <Switch checked={state.flyingKings} onChange={changeFlyingKings(onChange, state)} color="primary" />
       <Typography align="right">Stop Jumping If Piece Kinged</Typography>

--- a/web/src/games/checkers/customization.tsx
+++ b/web/src/games/checkers/customization.tsx
@@ -13,11 +13,24 @@ export enum piecesPerPlayer {
 export interface FullCustomizationState {
   piecesPerPlayer: piecesPerPlayer;
   flyingKings: boolean;
+  stopJumpOnKing: boolean;
 }
 
 export const DEFAULT_FULL_CUSTOMIZATION: FullCustomizationState = {
   piecesPerPlayer: piecesPerPlayer.TWELVE,
   flyingKings: false,
+  stopJumpOnKing: true,
+};
+
+const changePiecesPerPlayer = (onChange: (state?: FullCustomizationState) => void, state: FullCustomizationState) => (
+  event: React.ChangeEvent<{ value: piecesPerPlayer }>,
+) => {
+  const index = event.target.value;
+  const newState: FullCustomizationState = {
+    ...state,
+    piecesPerPlayer: index,
+  };
+  onChange(newState);
 };
 
 const changeFlyingKings = (onChange: (state?: FullCustomizationState) => void, state: FullCustomizationState) => () => {
@@ -28,13 +41,13 @@ const changeFlyingKings = (onChange: (state?: FullCustomizationState) => void, s
   onChange(newState);
 };
 
-const changePiecesPerPlayer = (onChange: (state?: FullCustomizationState) => void, state: FullCustomizationState) => (
-  event: React.ChangeEvent<{ value: piecesPerPlayer }>,
-) => {
-  const index = event.target.value;
+const changeStopJumpOnKing = (
+  onChange: (state?: FullCustomizationState) => void,
+  state: FullCustomizationState,
+) => () => {
   const newState: FullCustomizationState = {
     ...state,
-    piecesPerPlayer: index,
+    stopJumpOnKing: !state.stopJumpOnKing,
   };
   onChange(newState);
 };
@@ -52,13 +65,15 @@ const FullCustomization = ({ currentValue, onChange }: GameCustomizationProps) =
 
   return (
     <div style={style}>
-      <Typography align="right">Pieces per Player</Typography>
+      <Typography align="right">Pieces Per Player</Typography>
       <Select value={state.piecesPerPlayer} onChange={changePiecesPerPlayer(onChange, state)} style={{ width: '100%' }}>
         <MenuItem value={piecesPerPlayer.TWELVE}>12</MenuItem>
         <MenuItem value={piecesPerPlayer.EIGHT}>8</MenuItem>
       </Select>
       <Typography align="right">Flying Kings</Typography>
       <Switch checked={state.flyingKings} onChange={changeFlyingKings(onChange, state)} color="primary" />
+      <Typography align="right">Stop Jumping If Piece Kinged</Typography>
+      <Switch checked={state.stopJumpOnKing} onChange={changeStopJumpOnKing(onChange, state)} color="primary" />
     </div>
   );
 };

--- a/web/src/games/checkers/game.test.ts
+++ b/web/src/games/checkers/game.test.ts
@@ -25,6 +25,7 @@ it('should declare player 1 as the winner', () => {
       config: {
         ...DEFAULT_FULL_CUSTOMIZATION,
         flyingKings: true,
+        stopJumpOnKing: false,
       },
     }),
   };

--- a/web/src/games/checkers/game.test.ts
+++ b/web/src/games/checkers/game.test.ts
@@ -8,6 +8,7 @@ test('invalid moves', () => {
   let G: IG = {
     board: INITIAL_BOARD[0],
     jumping: null,
+    moveCount: 0,
     config: DEFAULT_FULL_CUSTOMIZATION,
   };
 
@@ -99,4 +100,54 @@ it('should declare player 1 as the winner', () => {
   // player '1' should be declared the winner
   const { ctx } = p0.getState();
   expect(ctx.gameover).toEqual({ winner: '1' });
+});
+
+it('should declare a draw', () => {
+  const CheckersGameWithSetup = {
+    ...CheckersGame,
+    setup: () => ({
+      board: INITIAL_BOARD[1],
+      jumping: null,
+      config: {
+        ...DEFAULT_FULL_CUSTOMIZATION,
+        forcedCapture: false,
+      },
+    }),
+  };
+
+  const spec = {
+    game: CheckersGameWithSetup,
+    multiplayer: Local(),
+  };
+
+  const p0 = Client({ ...spec, playerID: '0' } as any) as any;
+  const p1 = Client({ ...spec, playerID: '1' } as any) as any;
+
+  p0.start();
+  p1.start();
+
+  p0.moves.move({ x: 5, y: 6 }, { x: 4, y: 5 });
+  p1.moves.move({ x: 2, y: 1 }, { x: 3, y: 2 });
+  p0.moves.move({ x: 4, y: 5 }, { x: 3, y: 4 });
+  p1.moves.move({ x: 3, y: 2 }, { x: 4, y: 3 });
+  p0.moves.move({ x: 3, y: 4 }, { x: 2, y: 3 });
+  p1.moves.move({ x: 4, y: 3 }, { x: 5, y: 4 });
+  p0.moves.move({ x: 2, y: 3 }, { x: 1, y: 2 });
+  p1.moves.move({ x: 5, y: 4 }, { x: 6, y: 5 });
+  p0.moves.move({ x: 4, y: 7 }, { x: 5, y: 6 });
+  p1.moves.move({ x: 3, y: 0 }, { x: 2, y: 1 });
+  p0.moves.move({ x: 1, y: 2 }, { x: 3, y: 0 });
+  p1.moves.move({ x: 6, y: 5 }, { x: 4, y: 7 });
+
+  expect(p0.getState().G.moveCount).toEqual(0);
+
+  for (let i = 0; i < 20; i++) {
+    p0.moves.move({ x: 3, y: 0 }, { x: 2, y: 1 });
+    p1.moves.move({ x: 4, y: 7 }, { x: 5, y: 6 });
+    p0.moves.move({ x: 2, y: 1 }, { x: 3, y: 0 });
+    p1.moves.move({ x: 5, y: 6 }, { x: 4, y: 7 });
+  }
+
+  expect(p0.getState().G.moveCount).toEqual(80);
+  expect(p0.getState().ctx.gameover).toEqual({ winner: 'draw' });
 });

--- a/web/src/games/checkers/game.test.ts
+++ b/web/src/games/checkers/game.test.ts
@@ -2,11 +2,13 @@ import { INVALID_MOVE } from 'boardgame.io/core';
 import { Client } from 'boardgame.io/client';
 import { CheckersGame, IG, move, INITIAL_BOARD } from './game';
 import { Local } from 'boardgame.io/multiplayer';
+import { DEFAULT_FULL_CUSTOMIZATION } from './customization';
 
 test('invalid moves', () => {
   let G: IG = {
-    board: INITIAL_BOARD,
+    board: INITIAL_BOARD[0],
     jumping: null,
+    config: DEFAULT_FULL_CUSTOMIZATION,
   };
 
   const ctx: any = { playerID: '1' };
@@ -15,8 +17,19 @@ test('invalid moves', () => {
 });
 
 it('should declare player 1 as the winner', () => {
+  const CheckersGameWithSetup = {
+    ...CheckersGame,
+    setup: () => ({
+      board: INITIAL_BOARD[0],
+      jumping: null,
+      config: {
+        flyingKings: true,
+      },
+    }),
+  };
+
   const spec = {
-    game: CheckersGame,
+    game: CheckersGameWithSetup,
     multiplayer: Local(),
   };
 

--- a/web/src/games/checkers/game.test.ts
+++ b/web/src/games/checkers/game.test.ts
@@ -23,6 +23,7 @@ it('should declare player 1 as the winner', () => {
       board: INITIAL_BOARD[0],
       jumping: null,
       config: {
+        ...DEFAULT_FULL_CUSTOMIZATION,
         flyingKings: true,
       },
     }),

--- a/web/src/games/checkers/game.ts
+++ b/web/src/games/checkers/game.ts
@@ -186,6 +186,9 @@ export function move(G: IG, ctx: Ctx, from: ICoord, to: ICoord): IG | string {
   if (move.jumped === null) {
     return newG;
   }
+  if (G.config.stopJumpOnKing && !piece.isKing && to.y === crownhead) {
+    return newG;
+  }
 
   const jumping = {
     data: {

--- a/web/src/games/checkers/game.ts
+++ b/web/src/games/checkers/game.ts
@@ -136,7 +136,7 @@ export function getValidMoves(G: IG, playerID: string, jumping?: ICheckerPieceWi
     jumpedTotal = jumped;
   }
 
-  if (jumpedTotal) {
+  if ((jumpedTotal && G.config.forcedCapture) || jumping) {
     return movesTotal.filter((move) => move.jumped);
   } else {
     return movesTotal;

--- a/web/src/games/checkers/game.ts
+++ b/web/src/games/checkers/game.ts
@@ -42,6 +42,16 @@ export const INITIAL_BOARD: Piece[][] = [
     piece(12, 0),         null, piece(13, 0),         null, piece(14, 0),         null, piece(15, 0),         null,
             null, piece(16, 0),         null, piece(17, 0),         null, piece(18, 0),         null, piece(19, 0),
     piece(20, 0),         null, piece(21, 0),         null, piece(22, 0),         null, piece(23, 0),         null,
+  ],
+  [
+            null,  piece(0, 1),         null,  piece(1, 1),         null,  piece(2, 1),         null,  piece(3, 1),
+     piece(4, 1),         null,  piece(5, 1),         null,  piece(6, 1),         null,  piece(7, 1),         null,
+            null,         null,         null,         null,         null,         null,         null,         null,
+            null,         null,         null,         null,         null,         null,         null,         null,
+            null,         null,         null,         null,         null,         null,         null,         null,
+            null,         null,         null,         null,         null,         null,         null,         null,
+            null,  piece(8, 0),         null,  piece(9, 0),         null, piece(10, 0),         null, piece(11, 0),
+    piece(12, 0),         null, piece(13, 0),         null, piece(14, 0),         null, piece(15, 0),         null,
   ]
 ];
 
@@ -201,7 +211,7 @@ export const CheckersGame: Game<IG> = {
   setup: (_, customData: GameCustomizationState): IG => {
     const fullCustomization = (customData?.full as FullCustomizationState) || DEFAULT_FULL_CUSTOMIZATION;
     return {
-      board: INITIAL_BOARD[0],
+      board: INITIAL_BOARD[fullCustomization.piecesPerPlayer],
       jumping: null,
       config: fullCustomization,
     };

--- a/web/src/games/checkers/game.ts
+++ b/web/src/games/checkers/game.ts
@@ -26,6 +26,7 @@ type Piece = ICheckerPiece | null;
 export interface IG {
   board: Piece[];
   jumping: ICheckerPieceWithCoord;
+  moveCount: number;
   config: FullCustomizationState;
 }
 
@@ -163,6 +164,8 @@ export function move(G: IG, ctx: Ctx, from: ICoord, to: ICoord): IG | string {
   const jumped = move.jumped !== null ? toIndex(move.jumped) : -1;
   const isKing = piece.isKing || to.y === crownhead;
 
+  const moveCount = G.config.nMoveRule === -1 || move.jumped !== null || !piece.isKing ? 0 : G.moveCount + 1;
+
   const newG: IG = {
     ...G,
     board: G.board.map((square, i) => {
@@ -181,6 +184,7 @@ export function move(G: IG, ctx: Ctx, from: ICoord, to: ICoord): IG | string {
       }
     }),
     jumping: null,
+    moveCount,
   };
 
   if (move.jumped === null) {
@@ -216,6 +220,7 @@ export const CheckersGame: Game<IG> = {
     return {
       board: INITIAL_BOARD[fullCustomization.piecesPerPlayer],
       jumping: null,
+      moveCount: 0,
       config: fullCustomization,
     };
   },
@@ -232,6 +237,8 @@ export const CheckersGame: Game<IG> = {
   endIf: (G: IG, ctx) => {
     if (getValidMoves(G, ctx.currentPlayer === '0' ? '1' : '0').length === 0) {
       return { winner: ctx.currentPlayer };
+    } else if (G.config.nMoveRule !== -1 && G.moveCount >= G.config.nMoveRule * 2) {
+      return { winner: 'draw' };
     }
   },
 };

--- a/web/src/games/checkers/game.ts
+++ b/web/src/games/checkers/game.ts
@@ -1,6 +1,8 @@
 import { INVALID_MOVE } from 'boardgame.io/core';
 import { Ctx, Game } from 'boardgame.io';
 import { ICoord, sum, multiply, inBounds, toIndex, fromPosition, createCoord, equals } from './coord';
+import { GameCustomizationState } from 'gamesShared/definitions/customization';
+import { FullCustomizationState, DEFAULT_FULL_CUSTOMIZATION } from './customization';
 
 interface ICheckerPiece {
   id: number;
@@ -20,23 +22,27 @@ export interface IMove {
 }
 
 type Piece = ICheckerPiece | null;
+
 export interface IG {
   board: Piece[];
   jumping: ICheckerPieceWithCoord;
+  config: FullCustomizationState;
 }
 
 const piece = (id: number, player: number): ICheckerPiece => ({ id, playerID: player.toString(), isKing: false });
 
 // prettier-ignore
-export const INITIAL_BOARD: Piece[] = [
-          null,  piece(0, 1),         null,  piece(1, 1),         null,  piece(2, 1),         null,  piece(3, 1),
-   piece(4, 1),         null,  piece(5, 1),         null,  piece(6, 1),         null,  piece(7, 1),         null,
-          null,  piece(8, 1),         null,  piece(9, 1),         null, piece(10, 1),         null, piece(11, 1),
-          null,         null,         null,         null,         null,         null,         null,         null,
-          null,         null,         null,         null,         null,         null,         null,         null,
-  piece(12, 0),         null, piece(13, 0),         null, piece(14, 0),         null, piece(15, 0),         null,
-          null, piece(16, 0),         null, piece(17, 0),         null, piece(18, 0),         null, piece(19, 0),
-  piece(20, 0),         null, piece(21, 0),         null, piece(22, 0),         null, piece(23, 0),         null,
+export const INITIAL_BOARD: Piece[][] = [
+  [
+            null,  piece(0, 1),         null,  piece(1, 1),         null,  piece(2, 1),         null,  piece(3, 1),
+     piece(4, 1),         null,  piece(5, 1),         null,  piece(6, 1),         null,  piece(7, 1),         null,
+            null,  piece(8, 1),         null,  piece(9, 1),         null, piece(10, 1),         null, piece(11, 1),
+            null,         null,         null,         null,         null,         null,         null,         null,
+            null,         null,         null,         null,         null,         null,         null,         null,
+    piece(12, 0),         null, piece(13, 0),         null, piece(14, 0),         null, piece(15, 0),         null,
+            null, piece(16, 0),         null, piece(17, 0),         null, piece(18, 0),         null, piece(19, 0),
+    piece(20, 0),         null, piece(21, 0),         null, piece(22, 0),         null, piece(23, 0),         null,
+  ]
 ];
 
 const MAN_DIRS: ICoord[][] = [
@@ -55,11 +61,12 @@ export function checkPosition(
   const dirs = piece.isKing ? KING_DIRS : MAN_DIRS[playerID as any];
   let moves: IMove[] = [];
   let jumped = false;
+  const infiniteDistance: boolean = piece.isKing && G.config.flyingKings;
 
   for (const dir of dirs) {
     // Look into all valid directions
     let opponentBefore = null;
-    for (let i = 1; piece.isKing ? true : i < 3; i++) {
+    for (let i = 1; infiniteDistance ? true : i < 3; i++) {
       const final = sum(coord, multiply(dir, i));
 
       // Break if move is out of bounds
@@ -89,8 +96,8 @@ export function checkPosition(
           break;
         }
 
-        // If there is nothing and the piece isn't king there is no need to continue
-        if (!piece.isKing) {
+        // If there is nothing and the piece can't move infinitely there is no need to continue
+        if (!infiniteDistance) {
           break;
         }
       }
@@ -191,7 +198,14 @@ export function move(G: IG, ctx: Ctx, from: ICoord, to: ICoord): IG | string {
 
 export const CheckersGame: Game<IG> = {
   name: 'checkers',
-  setup: (): IG => ({ board: INITIAL_BOARD, jumping: null }),
+  setup: (_, customData: GameCustomizationState): IG => {
+    const fullCustomization = (customData?.full as FullCustomizationState) || DEFAULT_FULL_CUSTOMIZATION;
+    return {
+      board: INITIAL_BOARD[0],
+      jumping: null,
+      config: fullCustomization,
+    };
+  },
   moves: {
     move,
   },

--- a/web/src/games/checkers/index.ts
+++ b/web/src/games/checkers/index.ts
@@ -22,6 +22,7 @@ export const checkersGameDef: IGameDef = {
   status: IGameStatus.PUBLISHED,
   config: () => import('./config'),
   aiConfig: () => import('./ai'),
+  customization: () => import('./customization'),
 };
 
 export default checkersGameDef;

--- a/web/src/games/checkers/index.ts
+++ b/web/src/games/checkers/index.ts
@@ -1,14 +1,15 @@
 const Thumbnail = require('./media/thumbnail.jpg');
 import { GameMode } from 'gamesShared/definitions/mode';
-import { IGameDef, IGameStatus } from 'gamesShared/definitions/game';
+import { IGameDef, IGameStatus, IGameTranslationStatus } from 'gamesShared/definitions/game';
 import translation from './locales/en.json';
 
 export const checkersGameDef: IGameDef = {
   code: 'checkers',
   codes: { en: 'checkers', pt: 'damas', de: 'dame' },
   name: translation.name,
-  contributors: ['JosefKuchar'],
+  contributors: ['JosefKuchar', 'ProspectPyxis', 'mateusazis'],
   imageURL: Thumbnail,
+  translationStatus: { pt: IGameTranslationStatus.DONE, de: IGameTranslationStatus.PARTIAL },
   modes: [{ mode: GameMode.AI }, { mode: GameMode.OnlineFriend }, { mode: GameMode.LocalFriend }],
   minPlayers: 2,
   maxPlayers: 2,

--- a/web/src/games/checkers/index.ts
+++ b/web/src/games/checkers/index.ts
@@ -1,24 +1,20 @@
 const Thumbnail = require('./media/thumbnail.jpg');
 import { GameMode } from 'gamesShared/definitions/mode';
 import { IGameDef, IGameStatus } from 'gamesShared/definitions/game';
-import instructions from './instructions.md';
+import translation from './locales/en.json';
 
 export const checkersGameDef: IGameDef = {
   code: 'checkers',
   codes: { en: 'checkers', pt: 'damas', de: 'dame' },
-  name: 'Checkers',
+  name: translation.name,
   contributors: ['JosefKuchar'],
   imageURL: Thumbnail,
   modes: [{ mode: GameMode.AI }, { mode: GameMode.OnlineFriend }, { mode: GameMode.LocalFriend }],
   minPlayers: 2,
   maxPlayers: 2,
-  description: 'a Classic Game',
-  descriptionTag: `Play Checkers (also known as Draughts) locally
-  or online against friends!`,
-  instructions: {
-    videoId: 'ScKIdStgAfU',
-    text: instructions,
-  },
+  description: translation.description,
+  descriptionTag: translation.descriptionTag,
+  instructions: translation.instructions,
   status: IGameStatus.PUBLISHED,
   config: () => import('./config'),
   aiConfig: () => import('./ai'),

--- a/web/src/games/checkers/instructions.md
+++ b/web/src/games/checkers/instructions.md
@@ -1,7 +1,0 @@
-Checkers, also known as Draughts, is a board game for two players. It is played in a square board, made of 64 smaller squares, with eight squares on each side.
-
-Each player starts with an equal amount of pieces. The player with white pieces always makes the first move. Normal pieces can move only diagonally towards the opponent's side, while kings can move in any direction. A player can remove an opponent's piece from the board by jumping over it.
-
-In order to jump, the next diagonal square after the opponent piece must be empty. If the player has more than one possible jump, these jumps can be executed in a single turn. A piece becomes a king if a piece reaches the last row towards the opponent. The game ends when no more moves are possible for a player, either by losing all of their pieces or getting all their possible moves blocked.
-
-Checkers is a game with many variations across many regions of the world. The default settings of this game matches the standard rules of English Draughts - the most popular version of Checkers in America - but you should click the gear icon to change some settings and really make the game just as you know/want it!

--- a/web/src/games/checkers/instructions.md
+++ b/web/src/games/checkers/instructions.md
@@ -1,5 +1,7 @@
-Checkers is a board game for two players. It is played in a square board, made of 64 smaller squares, with eight squares on each side.
+Checkers, also known as Draughts, is a board game for two players. It is played in a square board, made of 64 smaller squares, with eight squares on each side.
 
-Each player starts with twelve pieces. The player with white pieces always makes the first move. Normal pieces can move only diagonally towards the opponent's side, while kings can move in any direction. A player can remove an opponent's piece from the board by jumping over it.
+Each player starts with an equal amount of pieces. The player with white pieces always makes the first move. Normal pieces can move only diagonally towards the opponent's side, while kings can move in any direction. A player can remove an opponent's piece from the board by jumping over it.
 
-In order to jump, the next diagonal square after the opponent piece must be empty. If the player has more than one possible jump, these jumps can be executed in a single turn. A piece becomes a king if a piece reaches the last row towards the opponent. The game ends when no more pieces or moves are possible for a player.
+In order to jump, the next diagonal square after the opponent piece must be empty. If the player has more than one possible jump, these jumps can be executed in a single turn. A piece becomes a king if a piece reaches the last row towards the opponent. The game ends when no more moves are possible for a player, either by losing all of their pieces or getting all their possible moves blocked.
+
+Checkers is a game with many variations across many regions of the world. The default settings of this game matches the standard rules of English Draughts - the most popular version of Checkers in America - but you should click the gear icon to change some settings and really make the game just as you know/want it!

--- a/web/src/games/checkers/locales/en.json
+++ b/web/src/games/checkers/locales/en.json
@@ -1,4 +1,33 @@
 {
   "name": "Checkers",
-  "description": "A classic game"
+  "description": "A classic game",
+  "descriptionTag": "Play Checkers (also known as Draughts) locally\nor online against friends!",
+  "instructions": {
+    "videoId": "ScKIdStgAfU",
+    "text": "Checkers, also known as Draughts, is a board game for two players. It is played in a square board, made of 64 smaller squares, with eight squares on each side.\n\nEach player starts with an equal amount of pieces. The player with white pieces always makes the first move. Normal pieces can move only diagonally towards the opponent's side, while kings can move in any direction. A player can remove an opponent's piece from the board by jumping over it.\n\nIn order to jump, the next diagonal square after the opponent piece must be empty. If the player has more than one possible jump, these jumps can be executed in a single turn. A piece becomes a king if a piece reaches the last row towards the opponent. The game ends when no more moves are possible for a player, either by losing all of their pieces or getting all their possible moves blocked.\n\nCheckers is a game with many possible rule variations. The default settings of this game matches the standard rules of English Draughts - the most popular version of Checkers in America - but you should also click the gear icon to change some settings and really make the game just as you know/want it!"
+  },
+
+  "customization": {
+    "pieces_per_player": "Pieces Per Player",
+    "forced_capture": "Forced Capture",
+    "flying_kings": "Kings Can Move Any Distance",
+    "stop_jump_on_king": "Stop Jumping If Piece Kinged",
+    "n_move_rule": {
+      "label": "Draw After n Moves Without Progress",
+      "off": "Off"
+    }
+  },
+
+  "move_piece": "Move piece",
+  "waiting_for_opponent": "Waiting for opponent...",
+  "white_turn": "White's turn",
+  "black_turn": "Black's turn",
+
+  "game_over": {
+    "you_won": "you won",
+    "you_lost": "you lost",
+    "white_won": "white won",
+    "black_won": "black won",
+    "draw": "draw"
+  }
 }

--- a/web/src/games/checkers/locales/pt.json
+++ b/web/src/games/checkers/locales/pt.json
@@ -1,4 +1,33 @@
 {
   "name": "Damas",
-  "description": "Um jogo clássico"
+  "description": "Um jogo clássico",
+  "descriptionTag": "Jogue damas com seus amigos localmente ou online !",
+  "instructions": {
+    "videoId": "ScKIdStgAfU",
+    "text": "Damas é um jogo de tabuleiro para duas pessoas, jogado em um tabuleiro quadrado feito de 64 quadrados menores, com 8 quadrados em cada lado.\n\nCada jogador começa com a mesma quantidade de peças e o jogador com peças brancas sempre inicia o jogo. Peças normais podem apenas se mover na diagonal em direção ao lado do oponente, enqunato damas podem se mover em qualquer direção. Um jogador pode comer a peça de um oponente pulando sobre ela.\n\nPara pular, o próximo espaço na diagonal do oponente precisa estar vazio. Se o jogador pode comer mais de um peça, pode o fazer no mesmo turno. Uma peça vira dama se chegar na ultima linha na direção do oponente. O jogo acaba quando não há mais movimentos possiveis para um jogador, por perder todas as peças ou não ter mais movimentos possíveis.\n\nDamas possui muitas variações nas regras, e as configurações por padrão usam as regras Inglesas  - a versão mais popular nos EUA - mas você pode clicar na pequena engrenagem para mudar algumas configurações e personalizar as regras como você está acostumado ou quer jogar!"
+  },
+
+  "customization": {
+    "pieces_per_player": "Peças por jogador",
+    "forced_capture": "Captura forçada",
+    "flying_kings": "Damas podem mover qualquer distância",
+    "stop_jump_on_king": "Parar de comer se a peça virou dama",
+    "n_move_rule": {
+      "label": "Empate após n movimentos sem progresso",
+      "off": "Desligado"
+    }
+  },
+
+  "move_piece": "Mover peça",
+  "waiting_for_opponent": "Esperando pelo oponente...",
+  "white_turn": "Turno do Branco",
+  "black_turn": "Turno do Preto",
+
+  "game_over": {
+    "you_won": "você ganhou",
+    "you_lost": "você perdeu",
+    "white_won": "branco ganhou",
+    "black_won": "preto ganhou",
+    "draw": "empate"
+  }
 }


### PR DESCRIPTION
#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] I've read and agree with the [contribution guidelines](https://www.freeboardgames.org/docs/?path=/story/documentation-contributing--page).

This adds, well, a lot of improvements to checkers, the biggest change being the new customization interface. If fully implemented, this should fully close both #604 and #946.

Please read through the list of changes carefully, as I've went ahead and made some changes that may be controversial - I can revert any changes that is believed to be a bad idea.

#### Changes Made:
- Rewrote all of `board.tsx` into a functional component, rather than a class component. React hooks are used to replicate all the functions of a class component's state, so functionally, this should be practically identical to before.
- Migrated all text to use the translate function. This is made possible by the functional component rewrite above. Please note two things about this change:
  - Despite the game already having locale files for `de` and `pt`, they are very much incomplete, practically not there at all - the only things translated are the game name and description. I know neither language, unfortunately, so I'm leaving it up to others to fill in the blanks.
  - I've rewritten the instruction text somewhat, the biggest change being that I added a new paragraph describing the game's settings being changeable in various ways. If you think this should be reverted, please let me know.
- Added *five* configuration options that directly affect the gameplay. I've also changed some defaults, so the game now plays a little differently from how it was before even if you don't touch the settings at all. As it stands, the ruleset should now closely imitate English Draughts by default, but let me know if any of the defaults should be changed around. The settings available are:
  - **Pieces Per Player** - set between 12 (default) or 8. I'll admit that this is a bit of self-indulgence on my part, as in my region, checkers are only played with 8 pieces per player, and I'd like to be able to play that variant on this site as well.
  - **Forced Capture** - on by default. Should be self-explanatory.
  - **Kings Can Move Any Distance** - off by default (used to be "enabled"). Also known as flying kings, this should be self-explanatory as well.
  - **Stop Jumping If Piece Kinged** - on by default (used to be "disabled"). If this option is on, a jump sequence immediately ends if the jumping piece turns into a king, so it can't continue capturing backwards.
  - **Draw After n Moves Without Progress** - set between off, 15, 30, or 40 (default). This is an entirely new rule that adds a draw condition to the game, to prevent games lasting forever due to, say, both players having one king each and just constantly jumping around avoiding each other without making a capture. In essence, this acts like chess's 50-move rule - if the selected amount of moves pass without either player making a capture or a non-king move, the game is automatically a draw.
- If forced capture is on and there are forced moves on the board, the selectable pieces are now highlighted cyan. This is basically a companion to #954 - players should be able to tell pieces they can select now even if there's more than one capture available on the board.

About the only thing left I haven't done is a better AI than randomly selected moves - I did give it a shot, but my minimax implementation was quite slow even at low depths, and I couldn't tell if that was an issue with my own code, if there's some existing unoptimized code in the game logic, or if it's just that slow normally, so in the end, I scrapped it and decided to make this PR as is. It's still something to look into at a later date, though.