### PR TITLE
Checkers: Bugfix, piece deselecting

### DIFF
--- a/web/src/games/checkers/board.tsx
+++ b/web/src/games/checkers/board.tsx
@@ -59,7 +59,11 @@ export function Board(props: IBoardProps) {
     if (selected === null && _isSelectable(position)) {
       setSelected(position);
     } else {
-      _move(position);
+      if (validMoves.some((move) => equals(move.to, position))) {
+        _move(position);
+      } else {
+        setSelected(_isSelectable(position) ? position : null);
+      }
     }
   };
 
@@ -106,6 +110,8 @@ export function Board(props: IBoardProps) {
       props.G.jumping === null
         ? getValidMoves(props.G, props.ctx.currentPlayer)
         : getValidMoves(props.G, props.ctx.currentPlayer, props.G.jumping);
+
+    if (newValidMoves.length === 0) return;
 
     setValidMoves(newValidMoves);
     setSelected(_getPreselectedMove(newValidMoves));

--- a/web/src/games/checkers/game.test.ts
+++ b/web/src/games/checkers/game.test.ts
@@ -71,12 +71,44 @@ test('stop jumping on king on/off', () => {
   expect(G.jumping).not.toEqual(null);
 });
 
+it("shouldn't end the game after one move", () => {
+  const CheckersGameWithSetup = {
+    ...CheckersGame,
+    setup: () => ({
+      board: convertStringToBoard('5p26p186p15P2888'),
+      jumping: null,
+      moveCount: 0,
+      config: {
+        ...DEFAULT_FULL_CUSTOMIZATION,
+      },
+    }),
+  };
+
+  const spec = {
+    game: CheckersGameWithSetup,
+    multiplayer: Local(),
+  };
+
+  const p0 = Client({ ...spec, playerID: '0' } as any) as any;
+  const p1 = Client({ ...spec, playerID: '1' } as any) as any;
+
+  p0.start();
+  p1.start();
+
+  p0.moves.move({ x: 5, y: 4 }, { x: 7, y: 2 });
+
+  // Even though white has no moves in this position, it's black to move
+  // The game should not be over yet
+  expect(p1.getState().ctx.gameover).toBeFalsy();
+});
+
 it('should declare player 1 as the winner', () => {
   const CheckersGameWithSetup = {
     ...CheckersGame,
     setup: () => ({
       board: convertStringToBoard(INITIAL_BOARD[0]),
       jumping: null,
+      moveCount: 0,
       config: {
         ...DEFAULT_FULL_CUSTOMIZATION,
         flyingKings: true,
@@ -162,6 +194,7 @@ it('should declare a draw', () => {
     setup: () => ({
       board: convertStringToBoard(INITIAL_BOARD[1]),
       jumping: null,
+      moveCount: 0,
       config: {
         ...DEFAULT_FULL_CUSTOMIZATION,
         forcedCapture: false,

--- a/web/src/games/checkers/game.ts
+++ b/web/src/games/checkers/game.ts
@@ -243,11 +243,14 @@ export const CheckersGame: Game<IG> = {
       first: () => 0,
       next: (G: IG, ctx) => (G.jumping === null ? (ctx.playOrderPos + 1) % ctx.numPlayers : ctx.playOrderPos),
     },
+    onBegin: (G: IG, ctx) => {
+      if (getValidMoves(G, ctx.currentPlayer).length === 0) {
+        ctx.events.endGame({ winner: ctx.currentPlayer === '0' ? '1' : '0' });
+      }
+    },
   },
-  endIf: (G: IG, ctx) => {
-    if (getValidMoves(G, ctx.currentPlayer === '0' ? '1' : '0').length === 0) {
-      return { winner: ctx.currentPlayer };
-    } else if (G.config.nMoveRule !== -1 && G.moveCount >= G.config.nMoveRule * 2) {
+  endIf: (G: IG) => {
+    if (G.config.nMoveRule !== -1 && G.moveCount >= G.config.nMoveRule * 2) {
       return { winner: 'draw' };
     }
   },


### PR DESCRIPTION
#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] I've read and agree with the [contribution guidelines](https://www.freeboardgames.org/docs/?path=/story/documentation-contributing--page).

This PR does two things:
- Fixed a bug with the game end logic. I've also added a new unit test that should check for this in the future.
  <details>
    <summary>Details of the bug</summary>
    Consider this position:

    ![image](https://user-images.githubusercontent.com/25642180/135051373-26fe1230-8b2f-46d1-9bf1-3390726bb3b1.png)

    After white takes the forced capture, white technically has no moves left (it's up against the edge, and its only square forward is blocked by two pieces). However, it should now be black's move, which means the game shouldn't end quite yet. With the former logic using `endIf`, the game would incorrectly end immediately after this move, since the game detects that white no longer has any moves remaining, but doesn't account for whose turn it is after the move.

    To fix this, I've simply moved the valid moves check to `onBegin`, and added a safety return to `board.tsx` to handle an empty valid move array, if it ever gets passed.
  </details>
- Pieces can now be deselected by simply clicking any other non-move square.

This should be the last bit of refactoring I'm doing with checkers for the time being if no new bugs are found - I've decided that implementing a better AI is something I wish to leave for the future.
