### PR TITLE
sixtysix: fix displayed melds

### DIFF
--- a/web/src/games/sixtysix/board.tsx
+++ b/web/src/games/sixtysix/board.tsx
@@ -228,11 +228,9 @@ export function BgioBoard(props: { G: IG; ctx: Ctx; moves: IGameMoves; playerID:
       if (G.exchanged9 == P.id) {
         return translate('announce_exchanged9');
       }
-      if (G.trick.leaderId != P.id || P.melds.length == 0) return null;
+      const gameTime = util.gameTime(G) + (G.trick.cards.length == 1 ? 1 : 0);
+      if (P.melds.length == 0 || G.lastMeldTime != gameTime) return null;
       const lastMeld = P.melds[P.melds.length - 1];
-      if (!util.meldSuits(P.hand.concat(G.trick.cards)).includes(lastMeld)) {
-        return null;
-      }
       const meldPoints = lastMeld == G.trumpSuit ? '(40)' : '(20)';
       return (
         <>
@@ -249,6 +247,7 @@ export function BgioBoard(props: { G: IG; ctx: Ctx; moves: IGameMoves; playerID:
         bidPass={G.players.map(() => false)}
         bidding={G.players.map(() => -1)}
         announcements={announcements}
+        announcementStyles={G.players.map(() => ({ color: 'black', backgroundColor: '#eee' }))}
         names={playerNames}
         hands={playerHands.map((H, i) => (G.players[i].id == playerID && !spectatorMode ? null : H))}
         pattern={Pattern.Skat}

--- a/web/src/games/sixtysix/game.ts
+++ b/web/src/games/sixtysix/game.ts
@@ -63,6 +63,7 @@ export const SixtysixGame: Game<IG> = {
         G.players.forEach((P, i) => {
           P.isReady = true;
           P.hand = G.deck.slice(i * handSize, (i + 1) * handSize).sort(cmpCards);
+          P.melds = [];
         });
       },
 

--- a/web/src/games/sixtysix/locales/de.json
+++ b/web/src/games/sixtysix/locales/de.json
@@ -14,7 +14,7 @@
   "button_close": "Decken",
   "button_meld": "Melden",
   "announce_meld": "Meldet",
-  "announce_exchanged9": "9 geraubt",
+  "announce_exchanged9": "Trumpf geraubt",
   "scoreboard_firstround": "Dies ist die erste Runde.",
   "scoreboard_round_n": "Runde {{ n }}",
   "scoreboard_points": "Punkte",

--- a/web/src/games/sixtysix/moves.ts
+++ b/web/src/games/sixtysix/moves.ts
@@ -57,6 +57,7 @@ export const Moves = {
       G.exchanged9 = null;
     }
     player.melds.push(suit);
+    G.lastMeldTime = util.gameTime(G);
     return G;
   },
 

--- a/web/src/games/sixtysix/types.ts
+++ b/web/src/games/sixtysix/types.ts
@@ -26,6 +26,7 @@ export interface IG {
   trumpSuit: Suit;
   trick: ITrick;
   exchanged9: string;
+  lastMeldTime: number;
   out: string;
   closed: boolean;
   resolvedTricks: ITrick[];
@@ -39,6 +40,7 @@ export const DefaultIG: IG = {
   trumpSuit: null,
   trick: { cards: [] },
   exchanged9: null,
+  lastMeldTime: null,
   out: null,
   closed: false,
   resolvedTricks: [],

--- a/web/src/games/sixtysix/util/misc.ts
+++ b/web/src/games/sixtysix/util/misc.ts
@@ -10,6 +10,10 @@ export function mod(n: number, m: number): number {
   return ((n % m) + m) % m;
 }
 
+export function gameTime(G: IG): number {
+  return G.stock.length + G.players.map((P) => P.hand.length).reduce((a, b) => a + b, 0);
+}
+
 export function suitRank(suit: Suit): number {
   return [Suit.Diamonds, Suit.Hearts, Suit.Spades, Suit.Clubs].indexOf(suit);
 }

--- a/web/src/gamesShared/components/cards/PlayerZones.tsx
+++ b/web/src/gamesShared/components/cards/PlayerZones.tsx
@@ -17,6 +17,7 @@ export function PlayerZones(props: {
   bidPass: boolean[];
   bidding: number[];
   announcements: (JSX.Element | string)[];
+  announcementStyles?: React.CSSProperties[];
   names: string[];
   hands: ICard[][];
   pattern: Pattern;
@@ -38,6 +39,10 @@ export function PlayerZones(props: {
     if (props.clockwise) {
       positionIndex = mod(numPlayers - positionIndex, numPlayers);
     }
+    let announceStyle = null;
+    if (props.announcementStyles && props.announcementStyles[index]) {
+      announceStyle = props.announcementStyles[index];
+    }
     return (
       <div key={index} className={css.zone}>
         <div
@@ -51,7 +56,9 @@ export function PlayerZones(props: {
         >
           <div>
             <div className={css.bidStatus}>
-              <div className={css.announcement}>{props.announcements[index]}</div>
+              <div className={css.announcement} style={announceStyle}>
+                {props.announcements[index]}
+              </div>
               <div className={props.bidPass[index] ? css.pass : ''}>{props.bids[index]}</div>
             </div>
             {!props.hands[index] ? null : (


### PR DESCRIPTION
After playing this game for a few rounds, we found that the melds ("marriages") of players are not correctly displayed on the opponent's screen, and melds wouldn't expire after each round. So, this small PR fixes this.

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] I've read and agree with the [contribution guidelines](https://www.freeboardgames.org/docs/?path=/story/documentation-contributing--page).
