### PR TITLE
[Mergers] Add mode where all player state is visible

### DIFF
--- a/web/src/games/mergers/Board.module.css
+++ b/web/src/games/mergers/Board.module.css
@@ -1,5 +1,4 @@
 .Mergers {
-  font-size: 1.25em;
   font-family: 'Roboto', 'Helvetica', 'Arial', sans-serif;
 
   /* Mergers colors */
@@ -17,7 +16,7 @@
   --chain-color-lucius: #f44336; /* material red 500 */
   --chain-color-festivus: #388e3c; /* material green 700 */
   --chain-color-amore: #0277bd; /* material blue 800 */
-  --chain-color-worldywise: #795548; /* material brown 500 */
+  --chain-color-worldlywise: #795548; /* material brown 500 */
   --chain-color-continuum: #0097a7; /* material teal 700 */
   --chain-color-imperative: #ad1457; /* material pink 800 */
 }
@@ -29,39 +28,6 @@
 .Mergers p {
   margin-bottom: 0;
   margin-top: 0;
-}
-
-.MergersContainer {
-  margin: 32px 10px 28px 10px;
-  box-sizing: border-box;
-  color: var(--mergers-color);
-  background-color: var(--mergers-background-color);
-}
-
-.AvailableStockAndPrice {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  margin-right: 0.5em;
-}
-
-.Player {
-  margin-right: 1em;
-  border: 4px solid transparent;
-  border-radius: 0.25em;
-  padding: 0.25em;
-}
-
-.Player.CurrentTurn {
-  border-color: var(--mergers-color);
-}
-
-.Player.YourTurn {
-  border-color: var(--mergers-highlight-green);
-}
-
-.PlayerMoney {
-  margin-right: 1em;
 }
 
 .WrapRow {
@@ -85,19 +51,6 @@
   margin-left: 1em;
 }
 
-.PlayerStock {
-  display: flex;
-  align-items: flex-end;
-  margin-right: 0.5em;
-}
-
-.PlayerStock.HiddenStock {
-  /* hide so height is maintained but width shrinks to 0 */
-  visibility: hidden;
-  width: 0;
-  margin: 0;
-}
-
 .MarginTopBottom {
   margin-bottom: 1em !important;
   margin-top: 1em !important;
@@ -117,4 +70,49 @@
 
 .MarginRight {
   margin-right: 1em;
+}
+
+.BoardContainer {
+  margin: 16px 10px 28px 10px;
+  box-sizing: border-box;
+  color: var(--mergers-color);
+  background-color: var(--mergers-background-color);
+}
+
+.BoardContainer > div {
+  margin: 1em 0;
+}
+
+.PlayerActionsContainer {
+  width: 100%;
+}
+
+.LastMoveAndCurrentTurnContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.LastMoveAndCurrentTurnContainer > div {
+  margin: 0.5em 0;
+}
+
+.Player {
+  margin-right: 0.5em;
+  border: 2px solid transparent;
+  border-radius: 0.25em;
+  padding: 0.25em;
+}
+
+.Player.CurrentTurn {
+  border-color: var(--mergers-color);
+}
+
+.Player.YourTurn {
+  border-color: var(--mergers-highlight-green);
+}
+
+.ShowGuideButtonContainer {
+  display: flex;
+  justify-content: center;
 }

--- a/web/src/games/mergers/board.test.tsx
+++ b/web/src/games/mergers/board.test.tsx
@@ -72,7 +72,7 @@ describe('Board', () => {
     it('renders the available stocks', () => {
       expect(comp.find('#available-stock-Toro').at(0).text()).toContain('25');
       expect(comp.find('#available-stock-Lucius').at(0).text()).toContain('25');
-      expect(comp.find('#available-stock-Worldywise').at(0).text()).toContain('25');
+      expect(comp.find('#available-stock-Worldlywise').at(0).text()).toContain('25');
       expect(comp.find('#available-stock-Amore').at(0).text()).toContain('25');
       expect(comp.find('#available-stock-Festivus').at(0).text()).toContain('25');
       expect(comp.find('#available-stock-Continuum').at(0).text()).toContain('25');
@@ -84,7 +84,7 @@ describe('Board', () => {
     });
 
     it('renders your money', () => {
-      expect(comp.find('#player-status').text()).toContain('You have:$6000');
+      expect(comp.find('#cash-0').text()).toContain('60');
     });
 
     it('does not render the merger dialog', () => {

--- a/web/src/games/mergers/components/HotelGrid.module.css
+++ b/web/src/games/mergers/components/HotelGrid.module.css
@@ -6,7 +6,6 @@
 }
 
 .HotelGrid {
-  margin-top: 0.5em;
   font-size: 40px;
   height: 100%;
   width: 100%;
@@ -78,8 +77,8 @@
   fill: var(--chain-color-amore);
 }
 
-.Hotel.Worldywise {
-  fill: var(--chain-color-worldywise);
+.Hotel.Worldlywise {
+  fill: var(--chain-color-worldlywise);
 }
 
 .Hotel.Continuum {

--- a/web/src/games/mergers/components/HotelGrid.tsx
+++ b/web/src/games/mergers/components/HotelGrid.tsx
@@ -148,7 +148,7 @@ export class HotelGrid extends React.Component<HotelGridProps, HotelGridState> {
     }
     return (
       <div className={css.HotelGridContainer}>
-        <svg viewBox="0 0 1300 1000" className={css.HotelGrid}>
+        <svg viewBox="0 0 1250 950" className={css.HotelGrid}>
           <g className={css.HotelGrid}>
             {this.renderColumnHeaders()}
             {this.props.hotels.hotelGrid().map(this.renderHotelRow.bind(this, chainTiles))}

--- a/web/src/games/mergers/components/MergersGameStatus.module.css
+++ b/web/src/games/mergers/components/MergersGameStatus.module.css
@@ -1,0 +1,116 @@
+.Player {
+  margin-right: 0.5em;
+  border: 2px solid transparent;
+  border-radius: 0.25em;
+  padding: 0.25em;
+}
+
+.Player.CurrentTurn {
+  border-color: var(--mergers-color);
+}
+
+.Player.YourTurn {
+  border-color: var(--mergers-highlight-green);
+}
+
+.NumberCell {
+  text-align: center;
+}
+
+.RowHeader {
+  text-align: left;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  max-width: 100px;
+}
+
+.ShadedRow {
+  color: var(--mergers-medium-grey);
+}
+
+.AllPlayerStateTable {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.AllPlayerStateTable table {
+  border-spacing: 0px;
+}
+
+.AllPlayerStateTable table th.ChainHeader {
+  border: 2px solid var(--mergers-background-color);
+  border-radius: 8px;
+  color: var(--mergers-background-color);
+}
+
+.AllPlayerStateTable table td.BorderTop {
+  border-top: 1px solid var(--mergers-medium-grey);
+  border-radius: 0px;
+}
+
+.AllPlayerStateTable td {
+  padding: 4px 6px;
+}
+
+.AllPlayerStateTable tr.PlayerRow {
+  font-weight: bold;
+}
+
+.AllPlayerStateTable th {
+  padding: 4px 6px;
+}
+
+@media only screen and (min-width: 601px) {
+  .RowHeader { max-width: 200px; }
+}
+
+@media only screen and (max-width: 600px) {
+  .AllPlayerStateTable { font-size: 18px; }
+  .RowHeader { max-width: 88px; }
+  .AllPlayerStateTable td { padding: 4px; }
+  .AllPlayerStateTable th { padding: 4px; }
+}
+
+@media only screen and (max-width: 350px) {
+  .AllPlayerStateTable { font-size: 14px; }
+  .RowHeader { max-width: 72px; }
+  .AllPlayerStateTable td { padding: 4px; }
+  .AllPlayerStateTable th { padding: 4px; }
+}
+
+@media only screen and (max-width: 300px) {
+  .AllPlayerStateTable { font-size: 12px; }
+  .RowHeader { max-width: 60px; }
+  .AllPlayerStateTable td { padding: 4px; }
+  .AllPlayerStateTable th { padding: 4px; }
+}
+
+.Toro {
+  background-color: var(--chain-color-toro);
+}
+
+.Lucius {
+  background-color: var(--chain-color-lucius);
+}
+
+.Festivus {
+  background-color: var(--chain-color-festivus);
+}
+
+.Amore {
+  background-color: var(--chain-color-amore);
+}
+
+.Worldlywise {
+  background-color: var(--chain-color-worldlywise);
+}
+
+.Continuum {
+  background-color: var(--chain-color-continuum);
+}
+
+.Imperative {
+  background-color: var(--chain-color-imperative);
+}

--- a/web/src/games/mergers/components/PlayerActions.module.css
+++ b/web/src/games/mergers/components/PlayerActions.module.css
@@ -14,12 +14,18 @@
   border-color: var(--mergers-highlight-green);
 }
 
+.FlexRow {
+  display: flex;
+  align-items: center;
+  margin: 0.25em 0;
+}
+
 .ActionButton {
   min-width: 80px;
 }
 
 .ActionInput {
-  width: 1em;
+  width: 1.25em;
 }
 
 .ErrorText {

--- a/web/src/games/mergers/components/PlayerActions.tsx
+++ b/web/src/games/mergers/components/PlayerActions.tsx
@@ -34,7 +34,7 @@ export class PlayerActions extends React.Component<PlayerActionsProps, PlayerAct
       stocksToBuy: {
         Toro: '',
         Lucius: '',
-        Worldywise: '',
+        Worldlywise: '',
         Amore: '',
         Festivus: '',
         Continuum: '',
@@ -133,7 +133,7 @@ export class PlayerActions extends React.Component<PlayerActionsProps, PlayerAct
 
   renderButton(text: string, onClick: () => void) {
     return (
-      <Button className={css.ActionButton} variant="contained" onClick={onClick}>
+      <Button className={css.ActionButton} variant="contained" color="primary" onClick={onClick}>
         {text}
       </Button>
     );
@@ -161,7 +161,7 @@ export class PlayerActions extends React.Component<PlayerActionsProps, PlayerAct
       .map((key) => this.renderChooseChainLabel(Chain[key]));
 
     return (
-      <div className={css.WrapRow}>
+      <div className={css.FlexRow}>
         <div className={css.MarginRight}>Choose the new chain:</div>
         {chainLabels}
       </div>
@@ -212,6 +212,7 @@ export class PlayerActions extends React.Component<PlayerActionsProps, PlayerAct
             className={css.ActionButton}
             disabled={!!errorMsg}
             variant="contained"
+            color="primary"
             onClick={() => {
               if (!!errorMsg) {
                 return;
@@ -253,7 +254,7 @@ export class PlayerActions extends React.Component<PlayerActionsProps, PlayerAct
         <StockLabel key={`stock-${chain}`} chain={chain} onClick={() => this.props.moves[move](chain)} />
       ));
     return (
-      <div id="break-merger-tie" className={css.WrapRow}>
+      <div id="break-merger-tie" className={css.FlexRow}>
         <div className={css.MarginRight}>{message}</div>
         {choices}
       </div>
@@ -309,7 +310,13 @@ export class PlayerActions extends React.Component<PlayerActionsProps, PlayerAct
           <div className={css.WrapRow}>
             {this.renderExchangeStockInput('Swap', setSwap, this.state.stocksToSwap)}
             {this.renderExchangeStockInput('Sell', setSell, this.state.stocksToSell)}
-            <Button className={css.ActionButton} variant="contained" onClick={onClick} disabled={!!errorMsg}>
+            <Button
+              className={css.ActionButton}
+              variant="contained"
+              color="primary"
+              onClick={onClick}
+              disabled={!!errorMsg}
+            >
               {stocksToExchange.swap + stocksToExchange.sell > 0 ? 'Exchange' : 'Keep all'}
             </Button>
           </div>

--- a/web/src/games/mergers/components/StockGuide.tsx
+++ b/web/src/games/mergers/components/StockGuide.tsx
@@ -34,7 +34,7 @@ export function StockGuide() {
     <th key="Header2">
       Amore
       <br />
-      Worldywise
+      Worldlywise
       <br />
       Festivus
     </th>,

--- a/web/src/games/mergers/components/StockLabel.module.css
+++ b/web/src/games/mergers/components/StockLabel.module.css
@@ -30,8 +30,8 @@
   background-color: var(--chain-color-amore);
 }
 
-.StockLabel.Worldywise {
-  background-color: var(--chain-color-worldywise);
+.StockLabel.Worldlywise {
+  background-color: var(--chain-color-worldlywise);
 }
 
 .StockLabel.Continuum {

--- a/web/src/games/mergers/customization.tsx
+++ b/web/src/games/mergers/customization.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { GameCustomization, GameCustomizationProps } from 'gamesShared/definitions/customization';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Switch from '@material-ui/core/Switch';
+
+import { Tooltip } from '@material-ui/core';
+
+export interface QuickCustomizationState {
+  isAllPlayerStateVisible: boolean;
+}
+
+export const DEFAULT_QUICK_CUSTOMIZATION = { isAllPlayerStateVisible: false };
+
+const QuickCustomization = ({ currentValue, onChange }: GameCustomizationProps) => {
+  const state = (currentValue as QuickCustomizationState) || DEFAULT_QUICK_CUSTOMIZATION;
+  return (
+    <Tooltip
+      leaveTouchDelay={3000}
+      enterTouchDelay={0}
+      arrow={true}
+      title="Enable to show each player's stocks and money to all other players"
+    >
+      <FormControlLabel
+        label="Show hands"
+        labelPlacement="start"
+        control={
+          <Switch
+            color="primary"
+            checked={state.isAllPlayerStateVisible}
+            onChange={(event) => onChange({ isAllPlayerStateVisible: event.target.checked })}
+          />
+        }
+      />
+    </Tooltip>
+  );
+};
+
+const customization: GameCustomization = {
+  QuickCustomization,
+};
+
+export default customization;

--- a/web/src/games/mergers/game.test.ts
+++ b/web/src/games/mergers/game.test.ts
@@ -993,16 +993,15 @@ describe('mergerPhase', () => {
       p1 = clients[1];
     });
 
-    it.only('completes the merger process twice', () => {
-      // DO NOT SUBMIT: DELETE it.only BEFORE MERGING!
+    it('completes the merger process twice', () => {
       expect(p0.store.getState().G.players['0'].money).toEqual(6000);
       expect(p1.store.getState().G.players['1'].money).toEqual(6000);
       expect(p0.store.getState().G.players['0'].stocks[Chain.Toro]).toEqual(1);
       expect(p0.store.getState().G.players['0'].stocks[Chain.Amore]).toEqual(0);
       expect(p0.store.getState().G.players['0'].stocks[Chain.Continuum]).toEqual(2);
-      expect(p0.store.getState().G.players['1'].stocks[Chain.Toro]).toEqual(0);
-      expect(p0.store.getState().G.players['1'].stocks[Chain.Amore]).toEqual(1);
-      expect(p0.store.getState().G.players['1'].stocks[Chain.Continuum]).toEqual(1);
+      expect(p1.store.getState().G.players['1'].stocks[Chain.Toro]).toEqual(0);
+      expect(p1.store.getState().G.players['1'].stocks[Chain.Amore]).toEqual(1);
+      expect(p1.store.getState().G.players['1'].stocks[Chain.Continuum]).toEqual(1);
 
       // place merger tile
       p0.moves.placeHotel('2-B');
@@ -1019,7 +1018,7 @@ describe('mergerPhase', () => {
       expect(p0.store.getState().ctx.phase).toEqual('mergerPhase');
       // awards bonuses (2000, 1000, both to p0)
       expect(p0.store.getState().G.players['0'].money).toEqual(9000);
-      expect(p0.store.getState().G.players['1'].money).toEqual(6000);
+      expect(p1.store.getState().G.players['1'].money).toEqual(6000);
       // p0 swaps and sells stock
       p0.moves.swapAndSellStock(0, 1); // swap 0, sell 1 (for 200)
       expect(p0.store.getState().G.players['0'].stocks[Chain.Toro]).toEqual(0);
@@ -1031,7 +1030,7 @@ describe('mergerPhase', () => {
       // merges Continuum
       // awards bonuses (4000 to p0, 2000 to p1)
       expect(p0.store.getState().G.players['0'].money).toEqual(13200);
-      expect(p0.store.getState().G.players['1'].money).toEqual(8000);
+      expect(p1.store.getState().G.players['1'].money).toEqual(8000);
       // p0 swaps and sells stock
 
       p0.moves.swapAndSellStock(2, 0); // swap 2, sell 0
@@ -1040,8 +1039,8 @@ describe('mergerPhase', () => {
       expect(p0.store.getState().G.players['0'].money).toEqual(13200);
       // p1 swaps and sells stock
       p1.moves.swapAndSellStock(0, 0); // swap 0, sell 0
-      expect(p0.store.getState().G.players['1'].stocks[Chain.Continuum]).toEqual(1);
-      expect(p0.store.getState().G.players['1'].money).toEqual(8000);
+      expect(p1.store.getState().G.players['1'].stocks[Chain.Continuum]).toEqual(1);
+      expect(p1.store.getState().G.players['1'].money).toEqual(8000);
 
       // moves on to buildingPhase
       expect(p0.store.getState().ctx.phase).toEqual('buildingPhase');
@@ -1106,12 +1105,12 @@ describe('mergerPhase', () => {
       expect(p0.store.getState().ctx.phase).toEqual('mergerPhase');
       // awards bonuses (2000, 1000, both to p1)
       expect(p0.store.getState().G.players['0'].money).toEqual(6000);
-      expect(p0.store.getState().G.players['1'].money).toEqual(9000);
+      expect(p1.store.getState().G.players['1'].money).toEqual(9000);
 
       // p1 exchanges stock
       p1.moves.swapAndSellStock(0, 1); // swaps 0, sells 1
-      expect(p0.store.getState().G.players['1'].stocks[Chain.Toro]).toEqual(0);
-      expect(p0.store.getState().G.players['1'].money).toEqual(9200);
+      expect(p1.store.getState().G.players['1'].stocks[Chain.Toro]).toEqual(0);
+      expect(p1.store.getState().G.players['1'].money).toEqual(9200);
 
       // moves on to buildingPhase
       expect(p0.store.getState().ctx.phase).toEqual('buildingPhase');
@@ -1166,6 +1165,9 @@ describe('mergers', () => {
         G.hotels = hotels;
         return G;
       },
+
+      // TODO: figure out why p2.moves.declareGameOver(true) fails without this
+      playerView: (G: IG) => G,
     };
     const clients = getMultiplayerTestClients(3, MergersCustomScenario);
 
@@ -1187,16 +1189,16 @@ describe('mergers', () => {
     p1.moves.chooseNewChain(Chain.Amore);
     p1.moves.buyStock({ [Chain.Amore]: 3 });
     p1.moves.drawHotels();
-    expect(p0.store.getState().G.players['1'].money).toEqual(5100);
-    expect(p0.store.getState().G.players['1'].stocks[Chain.Amore]).toEqual(4);
+    expect(p1.store.getState().G.players['1'].money).toEqual(5100);
+    expect(p1.store.getState().G.players['1'].stocks[Chain.Amore]).toEqual(4);
     expect(p0.store.getState().G.availableStocks[Chain.Amore]).toEqual(21);
 
     p2.moves.placeHotel('1-C');
     p2.moves.chooseNewChain(Chain.Continuum);
     p2.moves.buyStock({ [Chain.Continuum]: 3 });
     p2.moves.drawHotels();
-    expect(p0.store.getState().G.players['2'].money).toEqual(4800);
-    expect(p0.store.getState().G.players['2'].stocks[Chain.Continuum]).toEqual(4);
+    expect(p2.store.getState().G.players['2'].money).toEqual(4800);
+    expect(p2.store.getState().G.players['2'].stocks[Chain.Continuum]).toEqual(4);
     expect(p0.store.getState().G.availableStocks[Chain.Continuum]).toEqual(21);
 
     p0.moves.placeHotel('3-A');
@@ -1213,17 +1215,17 @@ describe('mergers', () => {
     p1.moves.placeHotel('4-D');
     p1.moves.buyStock({ [Chain.Continuum]: 1, [Chain.Amore]: 2 });
     p1.moves.drawHotels();
-    expect(p0.store.getState().G.players['1'].money).toEqual(3500);
-    expect(p0.store.getState().G.players['1'].stocks[Chain.Amore]).toEqual(6);
-    expect(p0.store.getState().G.players['1'].stocks[Chain.Continuum]).toEqual(1);
+    expect(p1.store.getState().G.players['1'].money).toEqual(3500);
+    expect(p1.store.getState().G.players['1'].stocks[Chain.Amore]).toEqual(6);
+    expect(p1.store.getState().G.players['1'].stocks[Chain.Continuum]).toEqual(1);
     expect(p0.store.getState().G.availableStocks[Chain.Amore]).toEqual(15);
     expect(p0.store.getState().G.availableStocks[Chain.Continuum]).toEqual(20);
 
     p2.moves.placeHotel('2-C');
     p2.moves.buyStock({ [Chain.Continuum]: 3 });
     p2.moves.drawHotels();
-    expect(p0.store.getState().G.players['2'].money).toEqual(3300);
-    expect(p0.store.getState().G.players['2'].stocks[Chain.Continuum]).toEqual(7);
+    expect(p2.store.getState().G.players['2'].money).toEqual(3300);
+    expect(p2.store.getState().G.players['2'].stocks[Chain.Continuum]).toEqual(7);
     expect(p0.store.getState().G.availableStocks[Chain.Continuum]).toEqual(17);
 
     p0.moves.placeHotel('4-A');
@@ -1239,28 +1241,28 @@ describe('mergers', () => {
     p1.moves.chooseNewChain(Chain.Toro);
     p1.moves.buyStock({ [Chain.Toro]: 1, [Chain.Amore]: 2 });
     p1.moves.drawHotels();
-    expect(p0.store.getState().G.players['1'].money).toEqual(1900);
-    expect(p0.store.getState().G.players['1'].stocks[Chain.Amore]).toEqual(8);
-    expect(p0.store.getState().G.players['1'].stocks[Chain.Continuum]).toEqual(1);
-    expect(p0.store.getState().G.players['1'].stocks[Chain.Toro]).toEqual(2);
+    expect(p1.store.getState().G.players['1'].money).toEqual(1900);
+    expect(p1.store.getState().G.players['1'].stocks[Chain.Amore]).toEqual(8);
+    expect(p1.store.getState().G.players['1'].stocks[Chain.Continuum]).toEqual(1);
+    expect(p1.store.getState().G.players['1'].stocks[Chain.Toro]).toEqual(2);
     expect(p0.store.getState().G.availableStocks[Chain.Amore]).toEqual(10);
     expect(p0.store.getState().G.availableStocks[Chain.Continuum]).toEqual(17);
     expect(p0.store.getState().G.availableStocks[Chain.Toro]).toEqual(22);
 
     p2.moves.placeHotel('2-B');
-    expect(p0.store.getState().G.players['1'].money).toEqual(4400);
-    expect(p0.store.getState().G.players['2'].money).toEqual(8300);
+    expect(p1.store.getState().G.players['1'].money).toEqual(4400);
+    expect(p2.store.getState().G.players['2'].money).toEqual(8300);
     p2.moves.swapAndSellStock(6, 1);
-    expect(p0.store.getState().G.players['2'].money).toEqual(8800);
-    expect(p0.store.getState().G.players['2'].stocks[Chain.Continuum]).toEqual(0);
-    expect(p0.store.getState().G.players['2'].stocks[Chain.Amore]).toEqual(3);
+    expect(p2.store.getState().G.players['2'].money).toEqual(8800);
+    expect(p2.store.getState().G.players['2'].stocks[Chain.Continuum]).toEqual(0);
+    expect(p2.store.getState().G.players['2'].stocks[Chain.Amore]).toEqual(3);
     p1.moves.swapAndSellStock(0, 1);
-    expect(p0.store.getState().G.players['1'].money).toEqual(4900);
-    expect(p0.store.getState().G.players['1'].stocks[Chain.Continuum]).toEqual(0);
+    expect(p1.store.getState().G.players['1'].money).toEqual(4900);
+    expect(p1.store.getState().G.players['1'].stocks[Chain.Continuum]).toEqual(0);
     p2.moves.buyStock({ [Chain.Amore]: 3 });
     p2.moves.drawHotels();
-    expect(p0.store.getState().G.players['2'].money).toEqual(6700);
-    expect(p0.store.getState().G.players['2'].stocks[Chain.Amore]).toEqual(6);
+    expect(p2.store.getState().G.players['2'].money).toEqual(6700);
+    expect(p2.store.getState().G.players['2'].stocks[Chain.Amore]).toEqual(6);
     expect(p0.store.getState().G.availableStocks[Chain.Amore]).toEqual(4);
 
     p0.moves.placeHotel('1-B');
@@ -1274,11 +1276,11 @@ describe('mergers', () => {
 
     p1.moves.placeHotel('4-C');
     expect(p0.store.getState().G.players['0'].money).toEqual(3300);
-    expect(p0.store.getState().G.players['1'].money).toEqual(6900);
+    expect(p1.store.getState().G.players['1'].money).toEqual(6900);
     p1.moves.swapAndSellStock(2);
-    expect(p0.store.getState().G.players['1'].money).toEqual(6900);
-    expect(p0.store.getState().G.players['1'].stocks[Chain.Toro]).toEqual(0);
-    expect(p0.store.getState().G.players['1'].stocks[Chain.Amore]).toEqual(9);
+    expect(p1.store.getState().G.players['1'].money).toEqual(6900);
+    expect(p1.store.getState().G.players['1'].stocks[Chain.Toro]).toEqual(0);
+    expect(p1.store.getState().G.players['1'].stocks[Chain.Amore]).toEqual(9);
     expect(p0.store.getState().G.availableStocks[Chain.Amore]).toEqual(0);
     p0.moves.swapAndSellStock(0, 1);
     expect(p0.store.getState().G.players['0'].money).toEqual(3500);
@@ -1296,9 +1298,9 @@ describe('mergers', () => {
     // 8000 bonus + 10 * 800 = 16000
     expect(p0.store.getState().G.players['0'].money).toEqual(19500);
     // 4000 bonus + 9 * 800 = 11200
-    expect(p0.store.getState().G.players['1'].money).toEqual(18100);
+    expect(p1.store.getState().G.players['1'].money).toEqual(18100);
     // 6 * 800 = 4800
-    expect(p0.store.getState().G.players['2'].money).toEqual(11500);
+    expect(p2.store.getState().G.players['2'].money).toEqual(11500);
 
     expect(p0.store.getState().ctx.gameover).toEqual({
       declaredBy: '2',

--- a/web/src/games/mergers/game.ts
+++ b/web/src/games/mergers/game.ts
@@ -1,4 +1,4 @@
-import { INVALID_MOVE } from 'boardgame.io/core';
+import { INVALID_MOVE, PlayerView } from 'boardgame.io/core';
 import { Game, Ctx } from 'boardgame.io';
 import { Chain, Hotel, Player, IG, Merger } from './types';
 import {
@@ -9,6 +9,8 @@ import {
   setupInitialState,
 } from './utils';
 import { Hotels } from './hotels';
+import { QuickCustomizationState, DEFAULT_QUICK_CUSTOMIZATION } from './customization';
+import { GameCustomizationState } from 'gamesShared/definitions/customization';
 
 export function getHotels(G: IG): Hotels {
   return new Hotels(G.hotels);
@@ -465,12 +467,16 @@ export function getMergerResults(G: IG, chainToMerge: Chain): Merger {
   };
 }
 
-// TODO: implement playerView
 export const MergersGame: Game<IG> = {
   name: 'mergers',
 
-  setup: (ctx: Ctx) => {
-    const G: IG = setupInitialState(ctx.numPlayers);
+  playerView: (G, ctx, playerID) => {
+    return G.isAllPlayerStateVisible ? G : PlayerView.STRIP_SECRETS(G, ctx, playerID);
+  },
+
+  setup: (ctx: Ctx, customData: GameCustomizationState) => {
+    const quickCustomization = (customData?.quick as QuickCustomizationState) || DEFAULT_QUICK_CUSTOMIZATION;
+    const G: IG = setupInitialState(ctx.numPlayers, quickCustomization.isAllPlayerStateVisible);
 
     setupInitialDrawing(G, ctx);
 

--- a/web/src/games/mergers/hotels.ts
+++ b/web/src/games/mergers/hotels.ts
@@ -120,7 +120,7 @@ export class Hotels {
       basePrice = 1000;
     }
 
-    if ([Chain.Worldywise, Chain.Amore, Chain.Festivus].includes(chain)) {
+    if ([Chain.Worldlywise, Chain.Amore, Chain.Festivus].includes(chain)) {
       return basePrice + 100;
     } else if ([Chain.Continuum, Chain.Imperative].includes(chain)) {
       return basePrice + 200;

--- a/web/src/games/mergers/index.ts
+++ b/web/src/games/mergers/index.ts
@@ -18,6 +18,7 @@ export const mergersGameDef: IGameDef = {
   },
   status: IGameStatus.PUBLISHED,
   config: () => import('./config'),
+  customization: () => import('./customization'),
 };
 
 export default mergersGameDef;

--- a/web/src/games/mergers/types.ts
+++ b/web/src/games/mergers/types.ts
@@ -1,5 +1,4 @@
 export interface IG {
-  // TODO: change this to { 'A1': Hotel } ?
   hotels?: Hotel[][];
   players?: Record<string, Player>;
   availableStocks?: Record<Chain, number>;
@@ -8,12 +7,13 @@ export interface IG {
   merger?: Merger;
   // See https://github.com/boardgameio/boardgame.io/issues/979
   isFirstTurnInPhase?: boolean;
+  isAllPlayerStateVisible?: boolean;
 }
 
 export enum Chain {
   Toro = 'Toro',
   Lucius = 'Lucius',
-  Worldywise = 'Worldywise',
+  Worldlywise = 'Worldlywise',
   Amore = 'Amore',
   Festivus = 'Festivus',
   Continuum = 'Continuum',

--- a/web/src/games/mergers/utils.ts
+++ b/web/src/games/mergers/utils.ts
@@ -3,12 +3,13 @@ import { Chain, IG, Player } from './types';
 
 const STOCK_PER_CHAIN = 25;
 
-export function setupInitialState(numPlayers: number): IG {
+export function setupInitialState(numPlayers: number, isAllPlayerStateVisible: boolean = false): IG {
   return {
     hotels: Hotels.buildGrid(),
     players: setupPlayers(numPlayers),
     availableStocks: fillStockMap(STOCK_PER_CHAIN),
     lastMove: '',
+    isAllPlayerStateVisible: isAllPlayerStateVisible,
   };
 }
 
@@ -29,7 +30,7 @@ export function fillStockMap<T>(value: T): Record<Chain, T> {
   return {
     Toro: value,
     Lucius: value,
-    Worldywise: value,
+    Worldlywise: value,
     Amore: value,
     Festivus: value,
     Continuum: value,


### PR DESCRIPTION
Adds a new mode where all players can see everyone's cash and stocks, in a table view. This mode is probably preferred for a lot of folks because all of the information in the game is public and trackable anyway, meaning if you just write down all the moves you can compute available cash and stocks for everyone.

In order to make the experience more consistent between modes, redesigns the regular mode view to use the same table, except with only one row showing your own state.

Switch (with details on hover):
<img width="507" alt="Screen Shot 2021-12-06 at 9 20 10 PM" src="https://user-images.githubusercontent.com/10420620/144954290-9ec91df1-4ad9-4644-bb15-3992450c39ef.png">

Mobile (tested on a bunch of dimensions):
<img width="413" alt="Screen Shot 2021-12-06 at 9 18 38 PM" src="https://user-images.githubusercontent.com/10420620/144954310-79829037-2676-4f6c-beb2-bd032f5be20f.png">

Desktop:
<img width="874" alt="Screen Shot 2021-12-06 at 9 18 52 PM" src="https://user-images.githubusercontent.com/10420620/144954323-1e3b4f5b-851a-4247-b7d0-f77dbfdde79b.png">

When not showing all hands:
<img width="413" alt="Screen Shot 2021-12-06 at 9 22 53 PM" src="https://user-images.githubusercontent.com/10420620/144954551-d6cb54fd-fcaa-4a15-b47d-a9842c613854.png">

Also:
- Switches buttons to "primary" color
- Fixes spelling of "Worldlywise'

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] I've read and agree with the [contribution guidelines](https://www.freeboardgames.org/docs/?path=/story/documentation-contributing--page).
