### PR TITLE
[Mergers] Do not run declareGameOver on the client

### DIFF
--- a/web/src/games/mergers/game.test.ts
+++ b/web/src/games/mergers/game.test.ts
@@ -1165,9 +1165,6 @@ describe('mergers', () => {
         G.hotels = hotels;
         return G;
       },
-
-      // TODO: figure out why p2.moves.declareGameOver(true) fails without this
-      playerView: (G: IG) => G,
     };
     const clients = getMultiplayerTestClients(3, MergersCustomScenario);
 

--- a/web/src/games/mergers/game.ts
+++ b/web/src/games/mergers/game.ts
@@ -511,7 +511,13 @@ export const MergersGame: Game<IG> = {
             moves: { buyStock },
           },
           declareGameOverStage: {
-            moves: { declareGameOver },
+            moves: {
+              declareGameOver: {
+                move: declareGameOver,
+                // Uses all player state, so do not run on the client
+                client: false,
+              },
+            },
           },
           drawHotelsStage: {
             moves: { drawHotels },


### PR DESCRIPTION
The move uses state that is hidden by playerView. This is currently broken.

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] I've read and agree with the [contribution guidelines](https://www.freeboardgames.org/docs/?path=/story/documentation-contributing--page).
