### PR TITLE
Add test playground for picnic go stats

### DIFF
--- a/web/src/games/picnicGoTest/board.tsx
+++ b/web/src/games/picnicGoTest/board.tsx
@@ -1,0 +1,125 @@
+import * as React from 'react';
+import { IGameArgs } from 'gamesShared/definitions/game';
+import { GameLayout } from 'gamesShared/components/fbg/GameLayout';
+import { Ctx } from 'boardgame.io';
+import { IG } from './game';
+
+interface IBoardProps {
+  G: IG;
+  ctx: Ctx;
+  moves: any;
+  playerID: string;
+  gameArgs?: IGameArgs;
+}
+
+export function Board(props: IBoardProps) {
+  function renderBoard() {
+    const countsN = props.G.counts.length;
+    const counts =
+      countsN == 0
+        ? new Array(12).fill(0)
+        : new Array(12).fill(0).map((_, i) => {
+            return props.G.counts.map((arr) => arr[i]).reduce((a, b) => a + b, 0);
+          });
+    const countsTotal = Math.max(
+      1,
+      counts.reduce((a, b) => a + b, 0),
+    );
+    const countsPerc = counts.map((n) => Math.round((100 * n) / countsTotal));
+    const countsCupcakes = (100 * props.G.counts.filter((arr) => arr[9] == 0).length) / Math.max(1, countsN);
+
+    const shuffleStatsN = props.G.shuffleStats.length;
+    const shuffleStats =
+      shuffleStatsN == 0
+        ? new Array(12).fill(0)
+        : new Array(12).fill(0).map((_, i) => {
+            return props.G.shuffleStats.map((arr) => arr[i]).reduce((a, b) => a + b, 0);
+          });
+    const shuffleStatsTotal = Math.max(
+      1,
+      shuffleStats.reduce((a, b) => a + b, 0),
+    );
+    const shuffleStatsPerc = shuffleStats.map((n) => Math.round((100 * n) / shuffleStatsTotal));
+    const shuffleStatsCupcakes =
+      (100 * props.G.shuffleStats.filter((arr) => arr[9] == 0).length) / Math.max(1, shuffleStatsN);
+
+    const expectedCounts = [5, 10, 5, 6, 12, 8, 14, 14, 14, 10, 6, 4];
+    const expectedTotal = expectedCounts.reduce((a, b) => a + b, 0);
+    const expectedPerc = expectedCounts.map((n) => Math.round((100 * n) / expectedTotal));
+
+    return (
+      <GameLayout gameArgs={props.gameArgs} maxWidth="750px">
+        <table style={{ width: '40em' }}>
+          <thead>
+            <tr style={{ fontSize: '0.6em' }}>
+              <th></th>
+              <th>Sandwich chicken</th>
+              <th>Sandwich pork</th>
+              <th>Sandwich beef</th>
+              <th>Chips potato 1</th>
+              <th>Chips potato 2</th>
+              <th>Chips potato 3</th>
+              <th>Deviled eggs</th>
+              <th>Fried chicken</th>
+              <th>Pizza</th>
+              <th>Cupcake</th>
+              <th>Mayo</th>
+              <th>Fork</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td style={{ textAlign: 'right' }}>Expected statistics (%)</td>
+              {expectedPerc.map((p, i) => (
+                <td key={i}>{p}</td>
+              ))}
+            </tr>
+            <tr>
+              <td style={{ textAlign: 'right' }}>Shuffle statistics (%)</td>
+              {shuffleStatsPerc.map((p, i) => (
+                <td key={i}>{p}</td>
+              ))}
+            </tr>
+            <tr>
+              <td style={{ textAlign: 'right' }}>Picnic Go statistics (%)</td>
+              {countsPerc.map((p, i) => (
+                <td key={i}>{p}</td>
+              ))}
+            </tr>
+          </tbody>
+        </table>
+        <p>
+          Statistics from N={shuffleStatsN} explicit shuffle operations (middle row)
+          <br /> and N={countsN} bgio {props.G.numPlayers}-player games of Picnic Go (last row)
+        </p>
+        <table style={{ width: '50em' }}>
+          <thead>
+            <tr>
+              <th></th>
+              <th>Expected value</th>
+              <th>Explicit shuffle</th>
+              <th>Picnic Go Implementation</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>No Cupcakes in start hand</td>
+              <td>{[11.66, 4.85, 2.47, 1.6][props.G.numPlayers - 2]}%</td>
+              <td>{Math.round(shuffleStatsCupcakes * 1e2) / 1e2}%</td>
+              <td>{Math.round(countsCupcakes * 1e2) / 1e2}%</td>
+            </tr>
+          </tbody>
+        </table>
+        <p>
+          <button onClick={() => props.moves.shuffleStatistics()}>Shuffle statistics</button>
+          <button onClick={() => props.moves.count(2)}>2-player game</button>
+          <button onClick={() => props.moves.count(3)}>3-player game</button>
+          <button onClick={() => props.moves.count(4)}>4-player game</button>
+          <button onClick={() => props.moves.count(5)}>5-player game</button>
+        </p>
+      </GameLayout>
+    );
+  }
+
+  return renderBoard();
+}

--- a/web/src/games/picnicGoTest/config.ts
+++ b/web/src/games/picnicGoTest/config.ts
@@ -1,0 +1,11 @@
+import { IGameConfig } from 'gamesShared/definitions/game';
+import { PicnicGoTGame } from './game';
+import { Board } from './board';
+
+const config: IGameConfig = {
+  bgioGame: PicnicGoTGame,
+  bgioBoard: Board,
+  debug: true,
+};
+
+export default config;

--- a/web/src/games/picnicGoTest/game.ts
+++ b/web/src/games/picnicGoTest/game.ts
@@ -1,0 +1,72 @@
+import { Ctx } from 'boardgame.io';
+import { ActivePlayers } from 'boardgame.io/core';
+import { Client } from 'boardgame.io/client';
+import { PicnicGoGame } from 'games/picnicGo/game';
+
+export interface IG {
+  counts: number[][];
+  shuffleStats: number[][];
+  numPlayers: number;
+}
+
+const cardTypes = [0, 5, 15, 20, 26, 38, 46, 60, 74, 88, 98, 104, 108];
+
+function countPicnicGoCards(numPlayers: number): number[] {
+  let cardCounts = new Array(12).fill(0);
+  const client = Client({
+    game: PicnicGoGame,
+    numPlayers,
+  });
+  const { G } = client.store.getState();
+  G.hands.forEach(({ hand }) => {
+    for (let i = 0; i < cardCounts.length; i++) {
+      cardCounts[i] += hand.filter((e) => cardTypes[i] <= e && e < cardTypes[i + 1]).length;
+    }
+  });
+  return cardCounts;
+}
+
+export function count(g: IG, ctx: Ctx, numPlayers: number) {
+  if (g.numPlayers != numPlayers) {
+    // reset counts when number of players changes
+    g.counts = [];
+    g.shuffleStats = [];
+    g.numPlayers = numPlayers;
+  }
+  for (let i = 0; i < 100; i++) {
+    g.counts.push(countPicnicGoCards(numPlayers));
+  }
+}
+
+export function shuffleStatistics(g: IG, ctx: Ctx) {
+  const N = 100;
+  const nCards = [20, 27, 32, 35][g.numPlayers - 2];
+  for (let n = 0; n < N; n++) {
+    let deck = new Array(108).fill(0).map((_, i) => i);
+    deck = ctx.random.Shuffle(deck).slice(-nCards);
+    let cardCounts = new Array(12).fill(0);
+    for (let i = 0; i < cardCounts.length; i++) {
+      cardCounts[i] += deck.filter((e) => cardTypes[i] <= e && e < cardTypes[i + 1]).length;
+    }
+    g.shuffleStats.push(cardCounts);
+  }
+}
+
+export const PicnicGoTGame = {
+  name: 'picnicGoT',
+  setup: () => {
+    return {
+      counts: [],
+      shuffleStats: [],
+      numPlayers: 4,
+    };
+  },
+
+  phases: {
+    play: {
+      start: true,
+      moves: { count, shuffleStatistics },
+      turn: { activePlayers: ActivePlayers.ALL },
+    },
+  },
+};

--- a/web/src/games/picnicGoTest/index.ts
+++ b/web/src/games/picnicGoTest/index.ts
@@ -1,0 +1,19 @@
+import { GameMode } from 'gamesShared/definitions/mode';
+import { IGameDef, IGameStatus } from 'gamesShared/definitions/game';
+
+export const picnicGoTGameDef: IGameDef = {
+  code: 'picnicGoT',
+  name: 'Picnic Go Test',
+  contributors: ['tuxor1337'],
+  imageURL: null,
+  modes: [{ mode: GameMode.OnlineFriend }],
+  minPlayers: 2,
+  maxPlayers: 2,
+  description: 'This is just a test playground for picnic go card statistics',
+  descriptionTag: "Don't use this!",
+  instructions: { text: "No instructions, don't use this if you don't know what you're doing." },
+  status: IGameStatus.IN_DEVELOPMENT,
+  config: () => import('./config'),
+};
+
+export default picnicGoTGameDef;


### PR DESCRIPTION
As discussed on Discord, this adds an unlisted game with status "IN_DEVELOPMENT" that serves as a playground of picnic go card statistics on Freeboardgames.org

I tested this functionality locally, and everything works as expected.

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] I've read and agree with the [contribution guidelines](https://www.freeboardgames.org/docs/?path=/story/documentation-contributing--page).
