### PR TITLE
fix(GamesList): work around to search translated games based on codes [#1056]

### DIFF
--- a/web/src/infra/common/components/game/GamesList.test.tsx
+++ b/web/src/infra/common/components/game/GamesList.test.tsx
@@ -14,6 +14,11 @@ describe('GamesList', () => {
   });
 
   describe('filtering', () => {
+    it('should filter by code', () => {
+      type(FIRST_GAME.codes.en || FIRST_GAME.code);
+      expect(screen.getByTestId(`gamecard-${FIRST_GAME.code}`)).toBeInTheDocument();
+    });
+
     it('should filter by name', () => {
       type(FIRST_GAME.name);
       expect(screen.getByTestId(`gamecard-${FIRST_GAME.code}`)).toBeInTheDocument();

--- a/web/src/infra/common/components/game/GamesList.tsx
+++ b/web/src/infra/common/components/game/GamesList.tsx
@@ -41,6 +41,8 @@ function useFilteredGamesList(searchQuery: string, options: { showDevOnly?: bool
     return getAllGames().filter((game) => {
       if (searchQuery) {
         return [
+          game?.code,
+          ...Object.values(game?.codes || []),
           game.name.toLowerCase(),
           game.description.toLowerCase(),
           game.descriptionTag.toLowerCase(),


### PR DESCRIPTION
#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] I've read and agree with the [contribution guidelines](https://www.freeboardgames.org/docs/?path=/story/documentation-contributing--page).


This is a very workaround to temporarily fix the search for translated games, as it relies on codes to search.
We should improve the way automate the GAMES_LIST, including their translated values.

PS: I wasn't able to run the unit tests for infra, not sure how to run them tbh. Will hope that CI will pass 🤞 