### PR TITLE
Add a bit more type information to functions/React states that use ICartesianCoords

### DIFF
--- a/web/src/games/bashni/board.tsx
+++ b/web/src/games/bashni/board.tsx
@@ -40,7 +40,7 @@ function roundCoords(coords: ICartesianCoords) {
 export function Board(props: IBoardProps) {
   const { translate } = useCurrentGameTranslation();
 
-  const [selected, setSelected] = React.useState(null);
+  const [selected, setSelected] = React.useState<ICartesianCoords | null>(null);
   const [validMoves, setValidMoves] = React.useState(getValidMoves(props.G, props.ctx.currentPlayer));
 
   function isInverted() {

--- a/web/src/games/checkers/board.tsx
+++ b/web/src/games/checkers/board.tsx
@@ -39,7 +39,7 @@ function roundCoords(coords: ICartesianCoords) {
 export function Board(props: IBoardProps) {
   const { translate } = useCurrentGameTranslation();
 
-  const [selected, setSelected] = React.useState(null);
+  const [selected, setSelected] = React.useState<ICartesianCoords | null>(null);
   const [validMoves, setValidMoves] = React.useState(getValidMoves(props.G, props.ctx.currentPlayer));
 
   function isInverted() {

--- a/web/src/gamesShared/components/boards/Checkerboard.tsx
+++ b/web/src/gamesShared/components/boards/Checkerboard.tsx
@@ -34,22 +34,27 @@ import { Grid } from 'deprecated-bgio-ui';
  */
 const NUM_COLS = 8;
 const NUM_ROWS = 8;
+
 export interface IAlgebraicCoords {
   square: string;
 }
+
 export interface ICartesianCoords {
   x: number;
   y: number;
 }
+
 export interface IOnDragData {
   x: number;
   y: number;
   originalX: number;
   originalY: number;
 }
+
 export interface IColorMap {
   [key: string]: string;
 }
+
 interface ICheckerboardProps {
   onClick: (coords: IAlgebraicCoords) => void;
   invert: boolean;
@@ -59,6 +64,7 @@ interface ICheckerboardProps {
   style: React.CSSProperties;
   children?: any;
 }
+
 export class Checkerboard extends React.Component<ICheckerboardProps, any> {
   static defaultProps = {
     invert: false,
@@ -118,7 +124,7 @@ export class Checkerboard extends React.Component<ICheckerboardProps, any> {
  * Given an algebraic notation, returns x and y values.
  * Example: A1 returns { x: 0, y: 0 }
  */
-export function algebraicToCartesian(square: string, invert?: boolean) {
+export function algebraicToCartesian(square: string, invert?: boolean): ICartesianCoords {
   const regexp = /([A-Za-z])([0-9]+)/g;
   const match = regexp.exec(square);
   if (match == null) {


### PR DESCRIPTION
Using

```typescript
const [selected, setSelected] = React.useState(null)
```

makes the TS compiler treat `selected` as being of type `any`. That is error prone (the compiler might not catch us calling a non-existing member) and it also makes autocomplete harder during development.

Also explicitly set `algebraicToCartesian`'s return type since the compiler can't infer that the object obeys the `ICartesianCoords` interface.

#### Checklist

* [X] Use a separate branch in your local repo (not `master`).
* [X] I've read and agree with the [contribution guidelines](https://www.freeboardgames.org/docs/?path=/story/documentation-contributing--page).
