### PR TITLE
Disable swear filter for private matches

### DIFF
--- a/fbg-server/src/chat/chat.service.spec.ts
+++ b/fbg-server/src/chat/chat.service.spec.ts
@@ -46,48 +46,48 @@ describe('ChatService', () => {
     let bobId, room, aliceId, channelId;
     const channelType = 'room';
     beforeAll(async () => {
-        bobId = await usersService.newUser({ nickname: 'bob' });
-        room = await roomsService.newRoom(
+      bobId = await usersService.newUser({ nickname: 'bob' });
+      room = await roomsService.newRoom(
         {
-            capacity: 2,
-            gameCode: 'checkers',
-            isPublic: false,
+          capacity: 2,
+          gameCode: 'checkers',
+          isPublic: true,
         },
         bobId,
-        );
-        channelId = room.id;
-        aliceId = await usersService.newUser({ nickname: 'alice' });
-        await roomsService.joinRoom(aliceId, room.id);
+      );
+      channelId = room.id;
+      aliceId = await usersService.newUser({ nickname: 'alice' });
+      await roomsService.joinRoom(aliceId, room.id);
     });
 
     it('should throw error for user not present', async () => {
-        const message = 'Hello, bob!';
-        const joeId = await usersService.newUser({ nickname: 'joe' });
-        const result = service.sendMessage(joeId, { channelType, channelId, message });
+      const message = 'Hello, bob!';
+      const joeId = await usersService.newUser({ nickname: 'joe' });
+      const result = service.sendMessage(joeId, { channelType, channelId, message });
 
-        await expect(result).rejects.toThrow();
+      await expect(result).rejects.toThrow();
     });
 
     it('should transmit a message succesfully', async () => {
-        const message = 'Hello, bob!';
-        jest.clearAllMocks();
-        const publish = jest.spyOn(pubSub, 'publish');
-        await service.sendMessage(aliceId, { channelType, channelId, message });
+      const message = 'Hello, bob!';
+      jest.clearAllMocks();
+      const publish = jest.spyOn(pubSub, 'publish');
+      await service.sendMessage(aliceId, { channelType, channelId, message });
 
-        const args = publish.mock.calls[0];
-        expect(args[0]).toEqual(`chat/room/${room.id}`);
-        expect(args[1].chatMutated.userNickname).toEqual('alice');
-        expect(args[1].chatMutated.message).toEqual(message);
+      const args = publish.mock.calls[0];
+      expect(args[0]).toEqual(`chat/room/${room.id}`);
+      expect(args[1].chatMutated.userNickname).toEqual('alice');
+      expect(args[1].chatMutated.message).toEqual(message);
     });
 
     it('should block bad words', async () => {
-        const message = 'Fuck!';
-        jest.clearAllMocks();
-        const publish = jest.spyOn(pubSub, 'publish');
-        await service.sendMessage(aliceId, { channelType, channelId, message });
+      const message = 'Fuck!';
+      jest.clearAllMocks();
+      const publish = jest.spyOn(pubSub, 'publish');
+      await service.sendMessage(aliceId, { channelType, channelId, message });
 
-        const args = publish.mock.calls[0];
-        expect(args[1].chatMutated.message).toEqual('****!');
+      const args = publish.mock.calls[0];
+      expect(args[1].chatMutated.message).toEqual('****!');
     });
   });
 
@@ -95,51 +95,51 @@ describe('ChatService', () => {
     let bobId, matchId, aliceId, channelId;
     const channelType = 'match';
     beforeAll(async () => {
-        const promiseMock = jest
+      const promiseMock = jest
         .fn()
         .mockReturnValueOnce(Promise.resolve({ data: { matchID: 'bgioGameId' } }))
         .mockReturnValueOnce(
-            Promise.resolve({ data: { playerCredentials: '1stSecret' } }),
+          Promise.resolve({ data: { playerCredentials: '1stSecret' } }),
         )
         .mockReturnValueOnce(
-            Promise.resolve({ data: { playerCredentials: '2ndSecret' } }),
+          Promise.resolve({ data: { playerCredentials: '2ndSecret' } }),
         );
-        jest
+      jest
         .spyOn(httpService, 'post')
         .mockReturnValue({ toPromise: promiseMock } as any);
-        bobId = await usersService.newUser({ nickname: 'bob' });
-        const room = await roomsService.newRoom(
+      bobId = await usersService.newUser({ nickname: 'bob' });
+      const room = await roomsService.newRoom(
         {
-            capacity: 2,
-            gameCode: 'checkers',
-            isPublic: false,
+          capacity: 2,
+          gameCode: 'checkers',
+          isPublic: true,
         },
         bobId,
-        );
-        aliceId = await usersService.newUser({ nickname: 'alice' });
-        await roomsService.joinRoom(aliceId, room.id);
-        matchId = await matchService.startMatch(room.id, bobId);
-        channelId = matchId;
+      );
+      aliceId = await usersService.newUser({ nickname: 'alice' });
+      await roomsService.joinRoom(aliceId, room.id);
+      matchId = await matchService.startMatch(room.id, bobId);
+      channelId = matchId;
     });
 
     it('should throw error for user not present', async () => {
-        const message = 'Hello, bob!';
-        const joeId = await usersService.newUser({ nickname: 'joe' });
-        const result = service.sendMessage(joeId, { channelType, channelId, message });
+      const message = 'Hello, bob!';
+      const joeId = await usersService.newUser({ nickname: 'joe' });
+      const result = service.sendMessage(joeId, { channelType, channelId, message });
 
-        await expect(result).rejects.toThrow();
+      await expect(result).rejects.toThrow();
     });
 
     it('should transmit a message succesfully', async () => {
-        const message = 'Hello, bob!';
-        jest.clearAllMocks();
-        const publish = jest.spyOn(pubSub, 'publish');
-        await service.sendMessage(aliceId, { channelType, channelId, message });
+      const message = 'Hello, bob!';
+      jest.clearAllMocks();
+      const publish = jest.spyOn(pubSub, 'publish');
+      await service.sendMessage(aliceId, { channelType, channelId, message });
 
-        const args = publish.mock.calls[0];
-        expect(args[0]).toEqual(`chat/match/${matchId}`);
-        expect(args[1].chatMutated.userNickname).toEqual('alice');
-        expect(args[1].chatMutated.message).toEqual(message);
+      const args = publish.mock.calls[0];
+      expect(args[0]).toEqual(`chat/match/${matchId}`);
+      expect(args[1].chatMutated.userNickname).toEqual('alice');
+      expect(args[1].chatMutated.message).toEqual(message);
     });
   })
 });

--- a/fbg-server/src/chat/chat.service.spec.ts
+++ b/fbg-server/src/chat/chat.service.spec.ts
@@ -42,7 +42,7 @@ describe('ChatService', () => {
     expect(service).toBeDefined();
   });
 
-  describe('room', () => {
+  describe('public room', () => {
     let bobId, room, aliceId, channelId;
     const channelType = 'room';
     beforeAll(async () => {
@@ -88,6 +88,35 @@ describe('ChatService', () => {
 
       const args = publish.mock.calls[0];
       expect(args[1].chatMutated.message).toEqual('****!');
+    });
+  });
+
+  describe('private room', () => {
+    let bobId, room, aliceId, channelId;
+    const channelType = 'room';
+    beforeAll(async () => {
+      bobId = await usersService.newUser({ nickname: 'bob' });
+      room = await roomsService.newRoom(
+        {
+          capacity: 2,
+          gameCode: 'checkers',
+          isPublic: false,
+        },
+        bobId,
+      );
+      channelId = room.id;
+      aliceId = await usersService.newUser({ nickname: 'alice' });
+      await roomsService.joinRoom(aliceId, room.id);
+    });
+
+    it('should NOT block bad words', async () => {
+      const message = 'Fuck!';
+      jest.clearAllMocks();
+      const publish = jest.spyOn(pubSub, 'publish');
+      await service.sendMessage(aliceId, { channelType, channelId, message });
+
+      const args = publish.mock.calls[0];
+      expect(args[1].chatMutated.message).toEqual('Fuck!');
     });
   });
 


### PR DESCRIPTION
#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] I've read and agree with the [contribution guidelines](https://www.freeboardgames.org/docs/?path=/story/documentation-contributing--page).

Exactly what it says on the tin: this completely disables the swear filter for private matches while still having it work in public games.

Manual testing indicates this works for both the room and match screens, but we're still missing automated tests.