### PR TITLE
Implement player ordering/shuffling in room view

### DIFF
--- a/common/gql/schema.gql
+++ b/common/gql/schema.gql
@@ -13,6 +13,7 @@ type NewUser {
 
 type RoomMembership {
   isCreator: Boolean!
+  position: Float!
   user: User!
 }
 
@@ -71,9 +72,10 @@ type Mutation {
   leaveRoom(roomId: String!): Boolean!
   removeFromRoom(roomId: String!, userIdToBeRemoved: Int!): Boolean!
   moveUserUp(roomId: String!, userIdToBeMovedUp: Int!): Boolean!
+  shuffleUsers(roomId: String!): Boolean!
   updateRoom(room: UpdateRoomInput!): Boolean!
   nextRoom(matchId: String!): String!
-  startMatch(roomId: String!, setupData: String!): String!
+  startMatch(roomId: String!, shuffleUsers: Boolean!, setupData: String!): String!
   sendMessage(message: SendMessageInput!): Boolean!
 }
 

--- a/common/gql/schema.gql
+++ b/common/gql/schema.gql
@@ -70,6 +70,7 @@ type Mutation {
   joinRoom(roomId: String!): Room!
   leaveRoom(roomId: String!): Boolean!
   removeFromRoom(roomId: String!, userIdToBeRemoved: Int!): Boolean!
+  moveUserUp(roomId: String!, userIdToBeMovedUp: Int!): Boolean!
   updateRoom(room: UpdateRoomInput!): Boolean!
   nextRoom(matchId: String!): String!
   startMatch(roomId: String!, setupData: String!): String!

--- a/fbg-server/src/healthz.controller.ts
+++ b/fbg-server/src/healthz.controller.ts
@@ -2,18 +2,19 @@ import { Controller, Get, HttpService } from '@nestjs/common';
 import { PORT } from './constants';
 
 const LOBBY_QUERY = `
-  query GetLobby { 
-    lobby { 
-      rooms { 
-        gameCode, 
-        capacity, 
-        userMemberships { 
-          isCreator, 
-          __typename 
-        }, 
-        __typename 
-      }, 
-      __typename 
+  query GetLobby {
+    lobby {
+      rooms {
+        gameCode,
+        capacity,
+        userMemberships {
+          isCreator,
+          position,
+          __typename
+        },
+        __typename
+      },
+      __typename
     }
   }
 `;

--- a/fbg-server/src/match/match.resolver.ts
+++ b/fbg-server/src/match/match.resolver.ts
@@ -32,8 +32,9 @@ export class MatchResolver {
   async startMatch(
     @CurrentUser() currentUser: User,
     @Args({ name: 'roomId', type: () => String }) roomId: string,
+    @Args({ name: 'shuffleUsers', type: () => Boolean }) shuffleUsers: boolean,
     @Args({ name: 'setupData', type: () => String }) setupData: string,
   ): Promise<string> {
-    return this.matchService.startMatch(roomId, currentUser.id, setupData);
+    return this.matchService.startMatch(roomId, currentUser.id, shuffleUsers, setupData);
   }
 }

--- a/fbg-server/src/match/match.service.ts
+++ b/fbg-server/src/match/match.service.ts
@@ -130,7 +130,7 @@ export class MatchService {
     newMatch.bgioMatchId = bgioMatchId;
     await queryRunner.manager.insert(MatchEntity, newMatch);
     let index = 0;
-    let memberships = room.userMemberships.slice();
+    const memberships = room.userMemberships.slice();
     if (shuffleUsers) {
       shuffleArray(memberships);
     } else {

--- a/fbg-server/src/rooms/RoomUtil.ts
+++ b/fbg-server/src/rooms/RoomUtil.ts
@@ -26,6 +26,7 @@ export function roomMembershipEntityToRoomMembership(
 ): RoomMembership {
   return {
     isCreator: roomMembershipEntity.isCreator,
+    position: roomMembershipEntity.position,
     user: roomMembershipEntity.user
       ? userEntityToUser(roomMembershipEntity.user)
       : undefined,

--- a/fbg-server/src/rooms/db/RoomMembership.entity.ts
+++ b/fbg-server/src/rooms/db/RoomMembership.entity.ts
@@ -18,6 +18,10 @@ export class RoomMembershipEntity extends BaseEntity {
   @Column({ type: 'double precision' })
   public lastSeen!: number;
 
+  @Index()
+  @Column({ type: 'integer', default: 0 })
+  public position!: number;
+
   @Column({ default: false })
   public isCreator!: boolean;
 

--- a/fbg-server/src/rooms/gql/RoomMembership.gql.ts
+++ b/fbg-server/src/rooms/gql/RoomMembership.gql.ts
@@ -4,5 +4,6 @@ import { User } from '../../users/gql/User.gql';
 @ObjectType()
 export class RoomMembership {
   isCreator: boolean;
+  position: number;
   user: User;
 }

--- a/fbg-server/src/rooms/rooms.resolver.ts
+++ b/fbg-server/src/rooms/rooms.resolver.ts
@@ -81,6 +81,19 @@ export class RoomsResolver {
 
   @Mutation(() => Boolean)
   @UseGuards(GqlAuthGuard)
+  async shuffleUsers(
+    @CurrentUser() currentUser: User,
+    @Args({ name: 'roomId', type: () => String }) roomId: string,
+  ): Promise<boolean> {
+    await this.roomsService.shuffleUsers(
+      currentUser.id,
+      roomId,
+    );
+    return true;
+  }
+
+  @Mutation(() => Boolean)
+  @UseGuards(GqlAuthGuard)
   async updateRoom(
     @CurrentUser() currentUser: User,
     @Args({ name: 'room', type: () => UpdateRoomInput }) room: UpdateRoomInput,

--- a/fbg-server/src/rooms/rooms.resolver.ts
+++ b/fbg-server/src/rooms/rooms.resolver.ts
@@ -65,6 +65,22 @@ export class RoomsResolver {
 
   @Mutation(() => Boolean)
   @UseGuards(GqlAuthGuard)
+  async moveUserUp(
+    @CurrentUser() currentUser: User,
+    @Args({ name: 'roomId', type: () => String }) roomId: string,
+    @Args({ name: 'userIdToBeMovedUp', type: () => Int })
+    userIdToBeMovedUp: number,
+  ): Promise<boolean> {
+    await this.roomsService.moveUserUp(
+      currentUser.id,
+      userIdToBeMovedUp,
+      roomId,
+    );
+    return true;
+  }
+
+  @Mutation(() => Boolean)
+  @UseGuards(GqlAuthGuard)
   async updateRoom(
     @CurrentUser() currentUser: User,
     @Args({ name: 'room', type: () => UpdateRoomInput }) room: UpdateRoomInput,

--- a/fbg-server/src/rooms/rooms.service.spec.ts
+++ b/fbg-server/src/rooms/rooms.service.spec.ts
@@ -169,7 +169,7 @@ describe('RoomsService', () => {
 
   it('should move up user successfully', async () => {
     const bobId = await usersService.newUser({ nickname: 'bob' });
-    const room = await service.newRoom(
+    let room = await service.newRoom(
       {
         capacity: 3,
         gameCode: 'checkers',
@@ -178,11 +178,21 @@ describe('RoomsService', () => {
       bobId,
     );
     const aliceId = await usersService.newUser({ nickname: 'alice' });
+
     await service.joinRoom(aliceId, room.id);
+    room = await service.getRoomEntity(room.id);
+    expect(room.userMemberships.length).toEqual(2);
+    expect(room.userMemberships[0].position).toEqual(1);
+    expect(room.userMemberships[0].user.id).toEqual(bobId);
+    expect(room.userMemberships[1].position).toEqual(2);
+    expect(room.userMemberships[1].user.id).toEqual(aliceId);
+
     await service.moveUserUp(bobId, aliceId, room.id);
     const newRoom = await service.getRoomEntity(room.id);
     expect(newRoom.userMemberships.length).toEqual(2);
-    expect(newRoom.userMemberships[0].user.id).toEqual(aliceId);
+    expect(newRoom.userMemberships[0].position).toEqual(1);
+    expect(newRoom.userMemberships[0].user.id).toEqual(aliceId);;
+    expect(newRoom.userMemberships[1].position).toEqual(2);
     expect(newRoom.userMemberships[1].user.id).toEqual(bobId);
   });
 

--- a/fbg-server/src/rooms/rooms.service.spec.ts
+++ b/fbg-server/src/rooms/rooms.service.spec.ts
@@ -63,7 +63,7 @@ describe('RoomsService', () => {
     );
     const newRoom = await service.getRoomEntity(room.id);
     expect(newRoom.userMemberships).toMatchObject([
-      { isCreator: true, user: { id: bobId, nickname: 'bob' } },
+      { isCreator: true, position: 1, user: { id: bobId, nickname: 'bob' } },
     ]);
   });
 

--- a/fbg-server/src/rooms/rooms.service.spec.ts
+++ b/fbg-server/src/rooms/rooms.service.spec.ts
@@ -167,6 +167,25 @@ describe('RoomsService', () => {
     expect(newRoom.userMemberships.length).toEqual(1);
   });
 
+  it('should move up user successfully', async () => {
+    const bobId = await usersService.newUser({ nickname: 'bob' });
+    const room = await service.newRoom(
+      {
+        capacity: 3,
+        gameCode: 'checkers',
+        isPublic: false,
+      },
+      bobId,
+    );
+    const aliceId = await usersService.newUser({ nickname: 'alice' });
+    await service.joinRoom(aliceId, room.id);
+    await service.moveUserUp(bobId, aliceId, room.id);
+    const newRoom = await service.getRoomEntity(room.id);
+    expect(newRoom.userMemberships.length).toEqual(2);
+    expect(newRoom.userMemberships[0].user.id).toEqual(aliceId);
+    expect(newRoom.userMemberships[1].user.id).toEqual(bobId);
+  });
+
   it('should notify about new room capacity and game', async () => {
     const bobId = await usersService.newUser({ nickname: 'bob' });
     const room = await service.newRoom(
@@ -200,9 +219,9 @@ describe('RoomsService', () => {
     const post = jest.spyOn(httpService, 'post').mockImplementation(() => ({ toPromise: () => Promise.resolve() }) as any);
     const webhookUrl = "https://foo";
     process.env.DISCORD_LETS_PLAY_WEBHOOK = webhookUrl;
-    
+
     await service.newRoom(room, bobId);
-    
+
     delete process.env.DISCORD_LETS_PLAY_WEBHOOK;
 
     const args = post.mock.calls[0];

--- a/fbg-server/src/rooms/rooms.service.ts
+++ b/fbg-server/src/rooms/rooms.service.ts
@@ -262,7 +262,7 @@ export class RoomsService {
       // nothing to do
       return;
     }
-    let newPositions = Array(memberships.length).fill(0).map((_, i) => i);
+    const newPositions = Array(memberships.length).fill(0).map((_, i) => i);
     shuffleArray(newPositions);
     memberships.forEach((m, i) => {
         m.position = newPositions[i];

--- a/fbg-server/src/rooms/rooms.service.ts
+++ b/fbg-server/src/rooms/rooms.service.ts
@@ -194,7 +194,7 @@ export class RoomsService {
       .leftJoinAndSelect('userMemberships.user', 'user')
       .where('room.id = :roomId', { roomId })
       .orderBy({
-        'userMemberships.id': 'ASC',
+        'userMemberships.position': 'ASC',
       })
       .getOne();
     if (!roomEntity) {

--- a/web/public/static/locales/de/ListPlayers.json
+++ b/web/public/static/locales/de/ListPlayers.json
@@ -1,6 +1,8 @@
 {
   "edit_nickname": "Nickname bearbeiten",
   "remove_user": "Benutzer entfernen",
+  "move_up_user": "Benutzer hochschieben",
+  "shuffle_users": "Benutzer mischen",
   "waiting_for_player": "Auf Spieler warten...",
   "players": "Spieler ({{ occupancy }}/{{ capacity }})"
 }

--- a/web/public/static/locales/de/StartMatchButton.json
+++ b/web/public/static/locales/de/StartMatchButton.json
@@ -1,5 +1,6 @@
 {
   "not_enough_players": "Nicht genügend Spieler.",
-  "only_creator_can_start": "Nur {{ name }} kann Starten.",
-  "start_match": "Partie Starten"
+  "only_creator_can_start": "Nur {{ name }} kann das Spiel starten.",
+  "start_match": "Spiel starten",
+  "start_match_shuffle": "Mit zufälliger Spielerreihenfolge starten"
 }

--- a/web/public/static/locales/en/ListPlayers.json
+++ b/web/public/static/locales/en/ListPlayers.json
@@ -2,6 +2,7 @@
   "edit_nickname": "Edit nickname",
   "remove_user": "Remove user",
   "move_up_user": "Move user up",
+  "shuffle_users": "Shuffle user ordering",
   "waiting_for_player": "Waiting for player...",
   "players": "Players ({{ occupancy }}/{{ capacity }})"
 }

--- a/web/public/static/locales/en/ListPlayers.json
+++ b/web/public/static/locales/en/ListPlayers.json
@@ -1,6 +1,7 @@
 {
   "edit_nickname": "Edit nickname",
   "remove_user": "Remove user",
+  "move_up_user": "Move user up",
   "waiting_for_player": "Waiting for player...",
   "players": "Players ({{ occupancy }}/{{ capacity }})"
 }

--- a/web/public/static/locales/en/StartMatchButton.json
+++ b/web/public/static/locales/en/StartMatchButton.json
@@ -1,5 +1,6 @@
 {
   "not_enough_players": "Not enough players.",
   "only_creator_can_start": "Only {{ name }} can start.",
-  "start_match": "Start match"
+  "start_match": "Start match",
+  "start_match_shuffle": "Start match with shuffled user ordering"
 }

--- a/web/public/static/locales/en/StartMatchButton.json
+++ b/web/public/static/locales/en/StartMatchButton.json
@@ -2,5 +2,5 @@
   "not_enough_players": "Not enough players.",
   "only_creator_can_start": "Only {{ name }} can start.",
   "start_match": "Start match",
-  "start_match_shuffle": "Start match with shuffled user ordering"
+  "start_match_shuffle": "Start with shuffled user ordering"
 }

--- a/web/public/static/locales/fr/ListPlayers.json
+++ b/web/public/static/locales/fr/ListPlayers.json
@@ -1,6 +1,8 @@
 {
   "edit_nickname": "Modifier pseudo",
   "remove_user": "Supprimer utilisateur",
+  "move_up_user": "Déplacer l'utilisateur vers le haut",
+  "shuffle_users": "Mélanger les utilisateurs",
   "waiting_for_player": "En attendant un joueur...",
   "players": "Joueurs ({{ occupancy }}/{{ capacity }})"
 }

--- a/web/public/static/locales/fr/StartMatchButton.json
+++ b/web/public/static/locales/fr/StartMatchButton.json
@@ -1,5 +1,6 @@
 {
   "not_enough_players": "Pas assez de joueurs.",
   "only_creator_can_start": "Seul {{ name }} peut commencer le jeu.",
-  "start_match": "Commencer le match"
+  "start_match": "Commencer le match",
+  "start_match_shuffle": "Commencer avec des utilisateurs mélangés"
 }

--- a/web/public/static/locales/it/ListPlayers.json
+++ b/web/public/static/locales/it/ListPlayers.json
@@ -1,6 +1,8 @@
 {
   "edit_nickname": "Modifica nickname",
   "remove_user": "Rimuovi utente",
+  "move_up_user": "Sposta l'utente in alto",
+  "shuffle_users": "Mischiare gli utenti",
   "waiting_for_player": "In attesa di giocatori...",
   "players": "Giocatori ({{ occupancy }}/{{ capacity }})"
 }

--- a/web/public/static/locales/it/StartMatchButton.json
+++ b/web/public/static/locales/it/StartMatchButton.json
@@ -1,5 +1,6 @@
 {
   "not_enough_players": "Non ci sono abbastanza giocatori.",
   "only_creator_can_start": "Solo {{ name }} può avviare la partita.",
-  "start_match": "Inizia la partita"
+  "start_match": "Inizia la partita",
+  "start_match_shuffle": "Iniziare con utenti mischiati"
 }

--- a/web/public/static/locales/pt/ListPlayers.json
+++ b/web/public/static/locales/pt/ListPlayers.json
@@ -1,6 +1,8 @@
 {
   "edit_nickname": "Editar apelido",
   "remove_user": "Remover usuário",
+  "move_up_user": "Mova o utilizador para cima",
+  "shuffle_users": "Baralhar os utilizadores",
   "waiting_for_player": "Aguardando jogador...",
   "players": "Jogadores ({{ occupancy }}/{{ capacity }})"
 }

--- a/web/public/static/locales/pt/StartMatchButton.json
+++ b/web/public/static/locales/pt/StartMatchButton.json
@@ -1,5 +1,6 @@
 {
   "not_enough_players": "Não há jogadores suficientes.",
   "only_creator_can_start": "Apenas {{ name }} pode iniciar.",
-  "start_match": "Iniciar Partida"
+  "start_match": "Iniciar Partida",
+  "start_match_shuffle": "Iniciar com utilizadores embaralhados"
 }

--- a/web/src/gqlTypes/GetLobby.ts
+++ b/web/src/gqlTypes/GetLobby.ts
@@ -10,6 +10,7 @@
 export interface GetLobby_lobby_rooms_userMemberships {
   __typename: "RoomMembership";
   isCreator: boolean;
+  position: number;
 }
 
 export interface GetLobby_lobby_rooms {

--- a/web/src/gqlTypes/JoinRoom.ts
+++ b/web/src/gqlTypes/JoinRoom.ts
@@ -16,6 +16,7 @@ export interface JoinRoom_joinRoom_userMemberships_user {
 export interface JoinRoom_joinRoom_userMemberships {
   __typename: "RoomMembership";
   isCreator: boolean;
+  position: number;
   user: JoinRoom_joinRoom_userMemberships_user;
 }
 

--- a/web/src/gqlTypes/MoveUserUp.ts
+++ b/web/src/gqlTypes/MoveUserUp.ts
@@ -1,0 +1,17 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL mutation operation: MoveUserUp
+// ====================================================
+
+export interface MoveUserUp {
+  moveUserUp: boolean;
+}
+
+export interface MoveUserUpVariables {
+  roomId: string;
+  userIdToBeMovedUp: number;
+}

--- a/web/src/gqlTypes/RoomMutated.ts
+++ b/web/src/gqlTypes/RoomMutated.ts
@@ -16,6 +16,7 @@ export interface RoomMutated_roomMutated_userMemberships_user {
 export interface RoomMutated_roomMutated_userMemberships {
   __typename: "RoomMembership";
   isCreator: boolean;
+  position: number;
   user: RoomMutated_roomMutated_userMemberships_user;
 }
 

--- a/web/src/gqlTypes/ShuffleUsers.ts
+++ b/web/src/gqlTypes/ShuffleUsers.ts
@@ -4,15 +4,13 @@
 // This file was automatically generated and should not be edited.
 
 // ====================================================
-// GraphQL mutation operation: StartMatch
+// GraphQL mutation operation: ShuffleUsers
 // ====================================================
 
-export interface StartMatch {
-  startMatch: string;
+export interface ShuffleUsers {
+  shuffleUsers: boolean;
 }
 
-export interface StartMatchVariables {
+export interface ShuffleUsersVariables {
   roomId: string;
-  shuffleUsers: boolean;
-  setupData: string;
 }

--- a/web/src/gqlTypes/SubscribeToLobby.ts
+++ b/web/src/gqlTypes/SubscribeToLobby.ts
@@ -10,6 +10,7 @@
 export interface SubscribeToLobby_lobbyMutated_rooms_userMemberships {
   __typename: "RoomMembership";
   isCreator: boolean;
+  position: boolean;
 }
 
 export interface SubscribeToLobby_lobbyMutated_rooms {

--- a/web/src/infra/common/services/LobbyService.ts
+++ b/web/src/infra/common/services/LobbyService.ts
@@ -182,6 +182,7 @@ export class LobbyService {
               userId
               userMemberships {
                 isCreator
+                position
                 user {
                   id
                   nickname
@@ -286,6 +287,7 @@ export class LobbyService {
               capacity
               userMemberships {
                 isCreator
+                position
               }
             }
           }

--- a/web/src/infra/common/services/LobbyService.ts
+++ b/web/src/infra/common/services/LobbyService.ts
@@ -17,6 +17,7 @@ import gql from 'graphql-tag.macro';
 import { JoinRoom, JoinRoomVariables } from 'gqlTypes/JoinRoom';
 import { RemoveUserFromRoom, RemoveUserFromRoomVariables } from 'gqlTypes/RemoveUserFromRoom';
 import { MoveUserUp, MoveUserUpVariables } from 'gqlTypes/MoveUserUp';
+import { ShuffleUsers, ShuffleUsersVariables } from 'gqlTypes/ShuffleUsers';
 import { UpdateRoomInput } from 'gqlTypes/globalTypes';
 
 const FBG_NICKNAME_KEY = 'fbgNickname2';
@@ -91,9 +92,11 @@ export class LobbyService {
       .catch(this.catchUnauthorizedGql(dispatch));
     return result.data;
   }
+
   public static async startMatch(
     dispatch: Dispatch<SyncUserAction>,
     roomId: string,
+    shuffleUsers?: boolean,
     rawSetupData?: unknown,
   ): Promise<string> {
     const client = this.getClient();
@@ -101,11 +104,11 @@ export class LobbyService {
     const result = await client
       .mutate<StartMatch, StartMatchVariables>({
         mutation: gql`
-          mutation StartMatch($roomId: String!, $setupData: String!) {
-            startMatch(roomId: $roomId, setupData: $setupData)
+          mutation StartMatch($roomId: String!, $shuffleUsers: Boolean!, $setupData: String!) {
+            startMatch(roomId: $roomId, shuffleUsers: $shuffleUsers, setupData: $setupData)
           }
         `,
-        variables: { roomId, setupData },
+        variables: { roomId, shuffleUsers, setupData },
       })
       .catch(this.catchUnauthorizedGql(dispatch));
     return result.data.startMatch;
@@ -239,6 +242,20 @@ export class LobbyService {
           }
         `,
         variables: { roomId, userIdToBeMovedUp },
+      })
+      .catch(this.catchUnauthorizedGql(dispatch));
+  }
+
+  public static async shuffleUsers(dispatch: Dispatch<SyncUserAction>, roomId: string): Promise<void> {
+    const client = this.getClient();
+    await client
+      .mutate<ShuffleUsers, ShuffleUsersVariables>({
+        mutation: gql`
+          mutation ShuffleUsers($roomId: String!) {
+            shuffleUsers(roomId: $roomId)
+          }
+        `,
+        variables: { roomId },
       })
       .catch(this.catchUnauthorizedGql(dispatch));
   }

--- a/web/src/infra/common/services/LobbyService.ts
+++ b/web/src/infra/common/services/LobbyService.ts
@@ -16,6 +16,7 @@ import { NextRoom, NextRoomVariables } from 'gqlTypes/NextRoom';
 import gql from 'graphql-tag.macro';
 import { JoinRoom, JoinRoomVariables } from 'gqlTypes/JoinRoom';
 import { RemoveUserFromRoom, RemoveUserFromRoomVariables } from 'gqlTypes/RemoveUserFromRoom';
+import { MoveUserUp, MoveUserUpVariables } from 'gqlTypes/MoveUserUp';
 import { UpdateRoomInput } from 'gqlTypes/globalTypes';
 
 const FBG_NICKNAME_KEY = 'fbgNickname2';
@@ -220,6 +221,24 @@ export class LobbyService {
           }
         `,
         variables: { roomId, userIdToBeRemoved },
+      })
+      .catch(this.catchUnauthorizedGql(dispatch));
+  }
+
+  public static async moveUpUser(
+    dispatch: Dispatch<SyncUserAction>,
+    userIdToBeMovedUp: number,
+    roomId: string,
+  ): Promise<void> {
+    const client = this.getClient();
+    await client
+      .mutate<MoveUserUp, MoveUserUpVariables>({
+        mutation: gql`
+          mutation MoveUserUp($roomId: String!, $userIdToBeMovedUp: Int!) {
+            moveUserUp(userIdToBeMovedUp: $userIdToBeMovedUp, roomId: $roomId)
+          }
+        `,
+        variables: { roomId, userIdToBeMovedUp },
       })
       .catch(this.catchUnauthorizedGql(dispatch));
   }

--- a/web/src/infra/lobby/LobbyCarousel.tsx
+++ b/web/src/infra/lobby/LobbyCarousel.tsx
@@ -24,6 +24,7 @@ export const LOBBIES_SUBSCRIPTION = gql`
         capacity
         userMemberships {
           isCreator
+          position
         }
       }
     }

--- a/web/src/infra/room/ListPlayers.stories.tsx
+++ b/web/src/infra/room/ListPlayers.stories.tsx
@@ -36,6 +36,14 @@ const editNickname = () => {
   alert('editNickname called');
 };
 
+const shuffleUsers = () => () => {
+  alert('shuffleUsers called');
+};
+
+const moveUpUser = () => () => {
+  alert('moveUpUser called');
+};
+
 const removeUser = () => () => {
   alert('removeUser called');
 };
@@ -49,6 +57,8 @@ export const example = () => (
     changeCapacity={changeCapacity}
     roomMetadata={roomMetadata}
     editNickname={editNickname}
+    shuffleUsers={shuffleUsers}
+    moveUpUser={moveUpUser}
     removeUser={removeUser}
     userId={1}
   />
@@ -58,6 +68,8 @@ export const isCreator = () => (
     changeCapacity={changeCapacity}
     roomMetadata={roomMetadata}
     editNickname={editNickname}
+    shuffleUsers={shuffleUsers}
+    moveUpUser={moveUpUser}
     removeUser={removeUser}
     userId={0}
   />

--- a/web/src/infra/room/ListPlayers.stories.tsx
+++ b/web/src/infra/room/ListPlayers.stories.tsx
@@ -14,6 +14,7 @@ const roomMetadata: JoinRoom_joinRoom = {
     {
       __typename: 'RoomMembership' as const,
       isCreator: true,
+      position: 1,
       user: {
         __typename: 'User' as const,
         id: 0,
@@ -23,6 +24,7 @@ const roomMetadata: JoinRoom_joinRoom = {
     {
       __typename: 'RoomMembership' as const,
       isCreator: false,
+      position: 2,
       user: {
         __typename: 'User' as const,
         id: 1,

--- a/web/src/infra/room/ListPlayers.test.tsx
+++ b/web/src/infra/room/ListPlayers.test.tsx
@@ -5,6 +5,7 @@ import { mount } from 'enzyme';
 const user1membership = {
   user: { nickname: 'foo', id: 123, __typename: 'User' as const },
   isCreator: true,
+  position: 1,
   __typename: 'RoomMembership' as const,
 };
 

--- a/web/src/infra/room/ListPlayers.tsx
+++ b/web/src/infra/room/ListPlayers.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PersonIcon from '@material-ui/icons/Person';
 import AccessTimeIcon from '@material-ui/icons/AccessTime';
 import RemoveCircleIcon from '@material-ui/icons/RemoveCircle';
+import ArrowUpwardIcon from '@material-ui/icons/ArrowUpward';
 import EditIcon from '@material-ui/icons/Edit';
 import { JoinRoom_joinRoom } from 'gqlTypes/JoinRoom';
 import AddIcon from '@material-ui/icons/Add';
@@ -30,6 +31,7 @@ interface IListPlayersOutterProps {
   roomMetadata: JoinRoom_joinRoom;
   userId?: number;
   editNickname: () => void;
+  moveUpUser: (userId: number) => () => void;
   removeUser: (userId: number) => () => void;
   changeCapacity: (delta: number) => () => void;
 }
@@ -58,12 +60,25 @@ export const ListPlayers = enhance(
 
     renderPlayersList() {
       const { t, roomMetadata: metadata } = this.props;
+      const currentUserIsCreator = isCreator(metadata, this.props.userId);
+      metadata.userMemberships.sort((m1, m2) => m1.position - m2.position);
 
       return metadata.userMemberships.map((membership, idx: number) => {
         let secondaryAction;
+        let moveUpButton;
+        if (idx > 0 && currentUserIsCreator) {
+          moveUpButton = (
+            <Tooltip title={t('move_up_user')} placement="top">
+              <Button data-testid="moveUpUser" onClick={this.props.moveUpUser(membership.user.id)}>
+                <ArrowUpwardIcon />
+              </Button>
+            </Tooltip>
+          );
+        }
         if (membership.user.id == this.props.userId) {
           secondaryAction = (
             <ListItemSecondaryAction>
+              {moveUpButton}
               <Tooltip title={t('edit_nickname')} placement="top">
                 <Button data-testid="editNickname" onClick={this.props.editNickname}>
                   <EditIcon />
@@ -71,9 +86,10 @@ export const ListPlayers = enhance(
               </Tooltip>
             </ListItemSecondaryAction>
           );
-        } else if (isCreator(metadata, this.props.userId)) {
+        } else if (currentUserIsCreator) {
           secondaryAction = (
             <ListItemSecondaryAction>
+              {moveUpButton}
               <Tooltip title={t('remove_user')} placement="top">
                 <Button data-testid="removeUser" onClick={this.props.removeUser(membership.user.id)}>
                   <RemoveCircleIcon />

--- a/web/src/infra/room/ListPlayers.tsx
+++ b/web/src/infra/room/ListPlayers.tsx
@@ -3,6 +3,7 @@ import PersonIcon from '@material-ui/icons/Person';
 import AccessTimeIcon from '@material-ui/icons/AccessTime';
 import RemoveCircleIcon from '@material-ui/icons/RemoveCircle';
 import ArrowUpwardIcon from '@material-ui/icons/ArrowUpward';
+import ShuffleIcon from '@material-ui/icons/Shuffle';
 import EditIcon from '@material-ui/icons/Edit';
 import { JoinRoom_joinRoom } from 'gqlTypes/JoinRoom';
 import AddIcon from '@material-ui/icons/Add';
@@ -31,6 +32,7 @@ interface IListPlayersOutterProps {
   roomMetadata: JoinRoom_joinRoom;
   userId?: number;
   editNickname: () => void;
+  shuffleUsers: () => () => void;
   moveUpUser: (userId: number) => () => void;
   removeUser: (userId: number) => () => void;
   changeCapacity: (delta: number) => () => void;
@@ -136,6 +138,7 @@ export const ListPlayers = enhance(
     }
 
     renderCapacityButtons() {
+      const t = this.props.t;
       const metadata = this.props.roomMetadata;
       let allDisabled = false;
       if (!isCreator(metadata, this.props.userId)) {
@@ -146,8 +149,19 @@ export const ListPlayers = enhance(
       const minCapacity = Math.max(gameDef.minPlayers, occupancy);
       const maxCapacity = gameDef.maxPlayers;
       const capacity = metadata.capacity;
+      let shuffleButton;
+      if (isCreator(metadata, this.props.userId)) {
+        shuffleButton = (
+          <Tooltip title={t('shuffle_users')} placement="top">
+            <Button data-testid="shuffleUsers" onClick={this.props.shuffleUsers()}>
+              <ShuffleIcon />
+            </Button>
+          </Tooltip>
+        );
+      }
       return (
         <ButtonGroup size="small" style={{ top: '8px', right: '8px', position: 'absolute', zIndex: 10 }}>
+          {shuffleButton}
           <Button onClick={this.props.changeCapacity(-1)} disabled={allDisabled || capacity - 1 < minCapacity}>
             <RemoveIcon />
           </Button>

--- a/web/src/infra/room/Room.test.tsx
+++ b/web/src/infra/room/Room.test.tsx
@@ -74,6 +74,7 @@ function getResultMock() {
     userMemberships: [
       {
         isCreator: true,
+        position: 1,
         user: { nickname: 'Bob', id: 1 },
       },
     ],

--- a/web/src/infra/room/Room.tsx
+++ b/web/src/infra/room/Room.tsx
@@ -139,6 +139,7 @@ class Room extends React.Component<InnerProps & OutterProps, State> {
                 <ListPlayers
                   roomMetadata={room}
                   editNickname={this._toggleEditingName}
+                  moveUpUser={this._moveUpUser}
                   removeUser={this._removeUser}
                   changeCapacity={this._changeCapacity}
                   userId={this.state.userId}
@@ -358,6 +359,11 @@ class Room extends React.Component<InnerProps & OutterProps, State> {
   _removeUser = (userIdToBeRemoved: number) => () => {
     const dispatch = (this.props as any).dispatch;
     LobbyService.removeUser(dispatch, userIdToBeRemoved, this._roomId());
+  };
+
+  _moveUpUser = (userIdToBeMovedUp: number) => () => {
+    const dispatch = (this.props as any).dispatch;
+    LobbyService.moveUpUser(dispatch, userIdToBeMovedUp, this._roomId());
   };
 
   _setNickname = (nickname: string) => {

--- a/web/src/infra/room/Room.tsx
+++ b/web/src/infra/room/Room.tsx
@@ -41,6 +41,7 @@ export const ROOM_SUBSCRIPTION = gql`
       userId
       userMemberships {
         isCreator
+        position
         user {
           id
           nickname
@@ -139,6 +140,7 @@ class Room extends React.Component<InnerProps & OutterProps, State> {
                 <ListPlayers
                   roomMetadata={room}
                   editNickname={this._toggleEditingName}
+                  shuffleUsers={this._shuffleUsers}
                   moveUpUser={this._moveUpUser}
                   removeUser={this._removeUser}
                   changeCapacity={this._changeCapacity}
@@ -366,6 +368,11 @@ class Room extends React.Component<InnerProps & OutterProps, State> {
     LobbyService.moveUpUser(dispatch, userIdToBeMovedUp, this._roomId());
   };
 
+  _shuffleUsers = () => () => {
+    const dispatch = (this.props as any).dispatch;
+    LobbyService.shuffleUsers(dispatch, this._roomId());
+  };
+
   _setNickname = (nickname: string) => {
     const { t } = this.props;
     this._toggleEditingName();
@@ -391,10 +398,10 @@ class Room extends React.Component<InnerProps & OutterProps, State> {
     return this.props.router.query.roomID as string;
   }
 
-  _startMatch = () => {
+  _startMatch = (shuffleUsers: boolean) => () => {
     const { t } = this.props;
     this.setState({ partialLoading: true });
-    LobbyService.startMatch(this.props.dispatch, this._roomId(), this.getSetupData()).then(
+    LobbyService.startMatch(this.props.dispatch, this._roomId(), shuffleUsers, this.getSetupData()).then(
       (matchId) => {
         this.redirectToMatch(matchId);
       },

--- a/web/src/infra/room/StartMatchButton.test.tsx
+++ b/web/src/infra/room/StartMatchButton.test.tsx
@@ -22,9 +22,10 @@ describe('Room Start Match Button', () => {
       ],
     };
     const wrapper = mount(<StartMatchButton roomMetadata={metadata} userId={1} startMatch={() => {}} />);
-    expect(wrapper.find(Button).getDOMNode()).toBeDisabled();
-    expect(wrapper.find(Button).text()).toBe('Start match');
-    expect(wrapper.find(Tooltip).prop('title')).toBe('Not enough players.');
+    expect(wrapper.find(Button).at(1).getDOMNode()).toBeDisabled();
+    expect(wrapper.find(Button).at(0).getDOMNode()).toBeDisabled();
+    expect(wrapper.find(Button).first().text()).toBe('Start match');
+    expect(wrapper.find(Tooltip).first().prop('title')).toBe('Not enough players.');
   });
 
   it('should show disabled button if not the creator', async () => {
@@ -49,9 +50,10 @@ describe('Room Start Match Button', () => {
       ],
     };
     const wrapper = mount(<StartMatchButton roomMetadata={metadata} userId={2} startMatch={() => {}} />);
-    expect(wrapper.find(Button).getDOMNode()).toBeDisabled();
-    expect(wrapper.find(Button).text()).toBe('Start match');
-    expect(wrapper.find(Tooltip).prop('title')).toBe('Only foo can start.');
+    expect(wrapper.find(Button).at(1).getDOMNode()).toBeDisabled();
+    expect(wrapper.find(Button).at(0).getDOMNode()).toBeDisabled();
+    expect(wrapper.find(Button).first().text()).toBe('Start match');
+    expect(wrapper.find(Tooltip).first().prop('title')).toBe('Only foo can start.');
   });
 
   it('should show enabled button if creator and full', async () => {
@@ -76,7 +78,8 @@ describe('Room Start Match Button', () => {
       ],
     };
     const wrapper = mount(<StartMatchButton roomMetadata={metadata} userId={1} startMatch={() => {}} />);
-    expect(wrapper.find(Button).getDOMNode()).toBeEnabled();
-    expect(wrapper.find(Button).text()).toBe('Start match');
+    expect(wrapper.find(Button).at(0).getDOMNode()).toBeEnabled();
+    expect(wrapper.find(Button).at(1).getDOMNode()).toBeEnabled();
+    expect(wrapper.find(Button).first().text()).toBe('Start match');
   });
 });

--- a/web/src/infra/room/StartMatchButton.test.tsx
+++ b/web/src/infra/room/StartMatchButton.test.tsx
@@ -17,6 +17,7 @@ describe('Room Start Match Button', () => {
         {
           __typename: 'RoomMembership' as const,
           isCreator: true,
+          position: 1,
           user: { nickname: 'Bob', id: 1, __typename: 'User' as const },
         },
       ],
@@ -40,11 +41,13 @@ describe('Room Start Match Button', () => {
         {
           __typename: 'RoomMembership' as const,
           isCreator: true,
+          position: 1,
           user: { nickname: 'foo', id: 1, __typename: 'User' as const },
         },
         {
           __typename: 'RoomMembership' as const,
           isCreator: false,
+          position: 2,
           user: { nickname: 'foo', id: 2, __typename: 'User' as const },
         },
       ],
@@ -68,11 +71,13 @@ describe('Room Start Match Button', () => {
         {
           __typename: 'RoomMembership' as const,
           isCreator: true,
+          position: 1,
           user: { nickname: 'foo', id: 1, __typename: 'User' as const },
         },
         {
           __typename: 'RoomMembership' as const,
           isCreator: false,
+          position: 2,
           user: { nickname: 'foo', id: 2, __typename: 'User' as const },
         },
       ],

--- a/web/src/infra/room/StartMatchButton.tsx
+++ b/web/src/infra/room/StartMatchButton.tsx
@@ -1,6 +1,8 @@
 import { JoinRoom_joinRoom } from 'gqlTypes/JoinRoom';
 import React from 'react';
+import ShuffleIcon from '@material-ui/icons/Shuffle';
 import Button from '@material-ui/core/Button';
+import ButtonGroup from '@material-ui/core/ButtonGroup';
 import Tooltip from '@material-ui/core/Tooltip';
 import { WithTranslation, withTranslation } from 'infra/i18n';
 import { compose } from 'recompose';
@@ -10,7 +12,7 @@ export interface IStartMatchButtonInnerProps extends WithTranslation {}
 export interface IStartMatchButtonOutterProps {
   roomMetadata?: JoinRoom_joinRoom;
   userId: number;
-  startMatch: () => void;
+  startMatch: (boolean) => () => void;
 }
 
 const enhance = compose<IStartMatchButtonInnerProps, IStartMatchButtonOutterProps>(withTranslation('StartMatchButton'));
@@ -28,25 +30,35 @@ export const StartMatchButton = enhance(
         disabled = true;
         explanation = this.props.t('only_creator_can_start', { name: creator.user.nickname });
       }
-      const button = (
+      let button = (
         <Button
           variant="outlined"
           color="primary"
           disabled={disabled}
-          onClick={this.props.startMatch}
+          onClick={this.props.startMatch(false)}
           data-testid="startButton"
         >
           {this.props.t('start_match')}
         </Button>
       );
       if (disabled) {
-        return (
-          <Tooltip title={explanation}>
-            <span>{button}</span>
-          </Tooltip>
-        );
+        button = <Tooltip title={explanation}>{button}</Tooltip>;
       }
-      return button;
+      return (
+        <ButtonGroup>
+          {button}
+          <Tooltip title={this.props.t('start_match_shuffle')}>
+            <Button
+              color="primary"
+              disabled={disabled}
+              onClick={this.props.startMatch(true)}
+              data-testid="startButtonWithShuffle"
+            >
+              <ShuffleIcon />
+            </Button>
+          </Tooltip>
+        </ButtonGroup>
+      );
     }
   },
 );


### PR DESCRIPTION
This implements reordering of players in game rooms. Players might want to be in the match in a certain order (or in random order). Currently, users are always listed in the order they joined the room in the first place. The only way to change the ordering with the current implementation is to kick users out and let them join again in the right order, shuffling is difficult.

This PR adds a "Move user up" and a "Shuffle users" button to the `ListPlayers` element, only available to the creator of the room. The order is realized by adding a `position` column in the membership database. Previously, memberships were sorted by `id`. Alternatively, the creator can also choose to shuffle the ordering immediately before the match starts, so that users don't know the ordering in advance.

![grafik](https://user-images.githubusercontent.com/1518387/167293599-fe89072b-3537-464d-a712-743ea3d62b89.png)

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] I've read and agree with the [contribution guidelines](https://www.freeboardgames.org/docs/?path=/story/documentation-contributing--page).
