### PR TITLE
schafkopf: fix selectable cards when player has called card

### DIFF
--- a/web/src/games/schafkopf/util/placement.ts
+++ b/web/src/games/schafkopf/util/placement.ts
@@ -32,6 +32,6 @@ export function selectableCards(G: IG, playerId: string): boolean[] {
     if (!has_called_card || lead_is_trump || lead_suit != calledCard.suit) {
       return is_lead_suit[i];
     }
-    return called_has_run || C.value == calledCard.value;
+    return is_lead_suit[i] && (called_has_run || C.value == calledCard.value);
   });
 }


### PR DESCRIPTION
This fixes a tiny bug in the Schafkopf UI. It was perfectly possible to play the game before this fix, but players could cheat in a certain situation.

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] I've read and agree with the [contribution guidelines](https://www.freeboardgames.org/docs/?path=/story/documentation-getting-started-contributing--page).
