### PR TITLE
typo in german translation of chess

### DIFF
--- a/web/src/games/chess/locales/de.json
+++ b/web/src/games/chess/locales/de.json
@@ -1,5 +1,5 @@
 {
-  "name": "Scach",
+  "name": "Schach",
   "description": "Internationale Regeln",
   "descriptionTag": "Spiele online Schach gegen\n\ntop Schach Computer. Du kannst das Computer Level von 1 bis 8,\n\nvon einfach bis Großmeister einstellen. Du kannst einen Invite Link erstellen, um\n\nmit einem Freund online zu spielen, oder Ihr teilt dein Gerät und\n\nspielt lokal !",
   "instructions": {


### PR DESCRIPTION
This is a tiny pull request that fixes a single character in a translation. But I thought it would be good if the game chess is spelled correctly in the German version of the site. :-)

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] I've read and agree with the [contribution guidelines](https://www.freeboardgames.org/docs/?path=/story/documentation-getting-started-contributing--page).
